### PR TITLE
Allow ts extension for useReact & useTS

### DIFF
--- a/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileTSX/legacy.js
+++ b/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileTSX/legacy.js
@@ -2,7 +2,7 @@ export const legacyCompileTSX = {
   module: {
     rules: [
       {
-        test: /\.(tsx)$/,
+        test: /\.(ts|tsx)$/,
         exclude: /node_modules/,
         use: [
           {

--- a/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileTSX/module.js
+++ b/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileTSX/module.js
@@ -2,7 +2,7 @@ export const moduleCompileTSX = {
   module: {
     rules: [
       {
-        test: /\.(tsx)$/,
+        test: /\.(ts|tsx)$/,
         exclude: /node_modules/,
         use: [
           {


### PR DESCRIPTION
Currently the TSX Loader (which is used, if useReact and useTS are activated) does not support the `.ts` file extension.

This prevents the usage of "simple" TypeScript files in combination with react.

In contrast the JSX Loader supports both `.js` and `.jsx`.