### PR TITLE
#23: fix watch stylemarks files:

### DIFF
--- a/packages/pv-stylemark/webpack-plugin/index.js
+++ b/packages/pv-stylemark/webpack-plugin/index.js
@@ -1,3 +1,5 @@
+const path = require("path");
+
 const buildStylemark = require("../scripts/buildStylemarkLsg");
 const { getFilesToWatch } = require("./getFilesToWatch");
 
@@ -14,6 +16,8 @@ class PvStylemarkPlugin {
       (compilation, callback) => {
         getFilesToWatch()
           .then(files => {
+            // make sure platform separator is used
+            files = files.map(path.normalize);
 
             if (Array.isArray(compilation.fileDependencies)) {
               compilation.fileDependencies.push(...files);


### PR DESCRIPTION
webpacks `compilation.fileDependencies` paths seem to have already been transformed to platform specific paths (i.e "\" instead of "/" for windows)
using `path.normalize` to tranform the new stylemark paths seem to solve the issue.
tested on a windows 10 machine.