### PR TITLE
use forward slashes for paths:

### DIFF
--- a/packages/pv-stylemark/gulp-tasks/clickdummy_tasks/assembleClickdummyComponents.js
+++ b/packages/pv-stylemark/gulp-tasks/clickdummy_tasks/assembleClickdummyComponents.js
@@ -1,7 +1,6 @@
 const assemble = require("@pro-vision/assemble-lite");
-const { join } = require("path");
 
-const { resolveApp, getAppConfig } = require("../../helper/paths");
+const { resolveApp, getAppConfig, join } = require("../../helper/paths");
 
 const {destPath, cdTemplatesSrc, componentsSrc, hbsHelperSrc} = getAppConfig();
 

--- a/packages/pv-stylemark/gulp-tasks/clickdummy_tasks/assembleClickdummyPages.js
+++ b/packages/pv-stylemark/gulp-tasks/clickdummy_tasks/assembleClickdummyPages.js
@@ -1,7 +1,6 @@
 const assemble = require("@pro-vision/assemble-lite");
-const { join } = require("path");
 
-const { resolveApp, getAppConfig } = require("../../helper/paths");
+const { resolveApp, getAppConfig, join } = require("../../helper/paths");
 
 const {destPath, cdTemplatesSrc, componentsSrc, cdPagesSrc, hbsHelperSrc} = getAppConfig();
 

--- a/packages/pv-stylemark/gulp-tasks/lsg_tasks/assembleLSGComponents.js
+++ b/packages/pv-stylemark/gulp-tasks/lsg_tasks/assembleLSGComponents.js
@@ -1,7 +1,6 @@
 const assemble = require("@pro-vision/assemble-lite");
-const { join } = require("path");
 
-const { resolveApp, getAppConfig } = require("../../helper/paths");
+const { resolveApp, getAppConfig, join } = require("../../helper/paths");
 
 const {destPath, lsgTemplatesSrc, componentsSrc, hbsHelperSrc} = getAppConfig();
 

--- a/packages/pv-stylemark/gulp-tasks/lsg_tasks/buildStylemark.js
+++ b/packages/pv-stylemark/gulp-tasks/lsg_tasks/buildStylemark.js
@@ -1,7 +1,6 @@
 const stylemark = require("stylemark");
-const { join } = require("path");
 
-const { resolveApp, getAppConfig } = require("../../helper/paths");
+const { resolveApp, getAppConfig, join } = require("../../helper/paths");
 
 const {destPath, lsgConfigPath} = getAppConfig();
 

--- a/packages/pv-stylemark/gulp-tasks/lsg_tasks/copyStyleguideFiles.js
+++ b/packages/pv-stylemark/gulp-tasks/lsg_tasks/copyStyleguideFiles.js
@@ -1,7 +1,6 @@
 const { src, dest, parallel} = require("gulp");
-const { join } = require("path");
 
-const { getAppConfig } = require("../../helper/paths");
+const { getAppConfig, join } = require("../../helper/paths");
 
 const {destPath, lsgAssetsSrc, componentsSrc} = getAppConfig();
 

--- a/packages/pv-stylemark/helper/paths.js
+++ b/packages/pv-stylemark/helper/paths.js
@@ -1,7 +1,8 @@
 
 
-const { resolve } = require("path");
+const { resolve, join } = require("path");
 const { realpathSync, existsSync } = require("fs");
+const slash = require("slash");
 
 const { defaultConfig } = require("../config/default.config");
 
@@ -26,7 +27,18 @@ if (customConfigExists) {
 
 const getAppConfig = () => config;
 
+/**
+ * node's `path.join`, but with forward slashes independent of the platform
+ *
+ * @param {...string} paths - path segments to be joined
+ * @returns {string}
+ */
+function slashJoin(...paths) {
+  return slash(join(...paths));
+}
+
 module.exports = {
   resolveApp,
-  getAppConfig
+  getAppConfig,
+  join: slashJoin
 };

--- a/packages/pv-stylemark/package.json
+++ b/packages/pv-stylemark/package.json
@@ -33,6 +33,7 @@
     "@pro-vision/assemble-lite": "^1.1.1",
     "cross-spawn": "6.0.5",
     "gulp": "4.0.2",
+    "slash": "3.0.0",
     "stylemark": "3.1.3"
   }
 }

--- a/packages/pv-stylemark/scripts/dev.js
+++ b/packages/pv-stylemark/scripts/dev.js
@@ -1,5 +1,4 @@
 const gulp = require("gulp");
-const { join } = require("path");
 
 // Assemble Clickdummy
 const { assembleClickdummyComponents } = require("../gulp-tasks/assembleWrapper/assembleClickdummyComponents");
@@ -9,7 +8,7 @@ const { copyClickdummyFiles } = require("../gulp-tasks/clickdummy_tasks/copyClic
 const { assembleLSGComponents } = require("../gulp-tasks/assembleWrapper/assembleLSGComponents");
 const { copyStyleguideFiles } = require("../gulp-tasks/lsg_tasks/copyStyleguideFiles");
 const { buildStylemark } = require("../gulp-tasks/lsg_tasks/buildStylemark");
-const { getAppConfig } = require("../helper/paths");
+const { getAppConfig, join } = require("../helper/paths");
 
 const recompileMessage = done => {
   console.log("Recompiling LSG...");

--- a/packages/pv-stylemark/webpack-plugin/getFilesToWatch.js
+++ b/packages/pv-stylemark/webpack-plugin/getFilesToWatch.js
@@ -1,7 +1,6 @@
 const { asyncGlob } = require("@pro-vision/assemble-lite/helper/io-helper");
-const { join } = require("path");
 
-const { getAppConfig } = require("../helper/paths");
+const { getAppConfig, join } = require("../helper/paths");
 
 const {componentsSrc, cdPagesSrc, cdTemplatesSrc, lsgIndex} = getAppConfig();
 

--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -62,6 +62,7 @@
     "regenerator-runtime": "0.13.3",
     "resolve": "^1.12.0",
     "sass-loader": "7.3.1",
+    "slash": "3.0.0",
     "style-loader": "1.0.0",
     "webpack": "4.39.3",
     "webpack-merge": "4.2.2"

--- a/packages/webpack-config/src/helpers/paths.js
+++ b/packages/webpack-config/src/helpers/paths.js
@@ -1,5 +1,6 @@
 import path from "path";
 import { realpathSync, existsSync } from "fs";
+import slash from "slash";
 
 import { defaultConfig } from "../config/default.config";
 
@@ -95,6 +96,16 @@ const getAppName = () => {
 export const appName = getAppName();
 
 export const shouldCopyResources = () => existsSync(resolveApp(getAppConfig().resourcesSrc));
+
+/**
+ * node's `path.join`, but with forward slashes independent of the platform
+ *
+ * @param {...string} paths - path segments to be joined
+ * @returns {string}
+ */
+export function join(...paths) {
+  return slash(path.join(...paths));
+}
 
 
 /******************************************************************************

--- a/packages/webpack-config/src/webpack/base/tasks/loadFonts.js
+++ b/packages/webpack-config/src/webpack/base/tasks/loadFonts.js
@@ -1,4 +1,4 @@
-import { publicPath, getAppConfig } from "../../../helpers/paths";
+import { publicPath, getAppConfig, join } from "../../../helpers/paths";
 
 const { fontsSrc } = getAppConfig();
 
@@ -11,7 +11,7 @@ export const loadFonts = {
           {
             loader: require.resolve("file-loader"),
             options: {
-              publicPath: `${publicPath.replace(/\/$/, "")}/${fontsSrc}`,
+              publicPath: join(publicPath, fontsSrc),
               name: "[name].[ext]",
               outputPath: fontsSrc
             }

--- a/packages/webpack-config/src/webpack/base/tasks/tsTypeChecking.js
+++ b/packages/webpack-config/src/webpack/base/tasks/tsTypeChecking.js
@@ -1,6 +1,5 @@
-import { appPath, appSrc } from "../../../helpers/paths";
+import { appPath, appSrc, join } from "../../../helpers/paths";
 
-const path = require("path");
 const resolve = require("resolve");
 const ForkTsCheckerWebpackPlugin = require("react-dev-utils/ForkTsCheckerWebpackPlugin");
 const typescriptFormatter = require("react-dev-utils/typescriptFormatter");
@@ -9,12 +8,12 @@ export const tsTypeChecking = {
   plugins: [
     new ForkTsCheckerWebpackPlugin({
       typescript: resolve.sync("typescript", {
-        basedir: path.join(appPath, "node_modules")
+        basedir: join(appPath, "node_modules")
       }),
       async: false,
       useTypescriptIncrementalApi: true,
       checkSyntacticErrors: true,
-      tsconfig: path.join(appPath, "tsconfig.json"),
+      tsconfig: join(appPath, "tsconfig.json"),
       eslint: true,
       reportFiles: ["**"],
       watch: appSrc,


### PR DESCRIPTION
most plugins expect paths / globs to be with forward slashes. when using `path.join`, slashes from the output will be converted always to forward slashes.
this will fix issues on windows machines where the outputs were not stored at the correct location