### PR TITLE
add rollup dependency to webpack-config module:

### DIFF
--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -65,5 +65,8 @@
     "style-loader": "1.0.0",
     "webpack": "4.39.3",
     "webpack-merge": "4.2.2"
+  },
+  "devDependencies": {
+    "rollup": "1.22.0"
   }
 }


### PR DESCRIPTION

== Description ==
webpack-config uses rollup in its build npm script, to allow buildng this package independent of the parent package, rollup needs to be defined as dev-dependency

== Closes issue(s) ==
non opened

== Changes ==


== Affected Packages ==
webpack-config, only dev dependency