### PR TITLE
log expetion which was thrown during reading and initializing the web…

### DIFF
--- a/packages/webpack-config/src/helpers/paths.js
+++ b/packages/webpack-config/src/helpers/paths.js
@@ -37,7 +37,9 @@ export const getCustomWebpackConfig = configName =>
       try {
         customWebpackConfig = require(customWebpackConfigPath);
       }
-      catch {
+      catch (err) {
+        console.log("Failed to load config file:");
+        console.error(err);
         customWebpackConfig = {};
       }
       finally {


### PR DESCRIPTION
…pack plugins from custom webpack config, to allow errors to be visible

== Description ==
Reading the custom webpack config happens inside a try/cach statement. To allow the users to notice if in the file or in the construction call of the used webpack plugins an exeption is thrown, the error is logged in the cli.

== Closes issue(s) ==

non opened
== Changes ==
webpack-config

== Affected Packages ==
