### PR TITLE
Add port number to console.log on launching WebpackDevServer

### DIFF
--- a/packages/pv-scripts/scripts/dev.js
+++ b/packages/pv-scripts/scripts/dev.js
@@ -46,7 +46,7 @@ prepareWebpackConfig("development")
         clearConsole();
       }
 
-      console.log(chalk.cyan("Starting the development server...\n"));
+      console.log(chalk.cyan(`Starting the development server on port ${devServerConfig.port}...\n`));
     });
 
     ["SIGINT", "SIGTERM"].forEach(sig => {


### PR DESCRIPTION
== Description ==

Add port number to console.log on launching WebpackDevServer

== Closes issue(s) ==

n/a

== Changes ==

`packages/pv-scripts/scripts/dev.js`

== Affected Packages ==

`packages/pv-scripts`