### PR TITLE
Add devserver url to console output

### DIFF
--- a/packages/pv-scripts/scripts/dev.js
+++ b/packages/pv-scripts/scripts/dev.js
@@ -37,7 +37,7 @@ prepareWebpackConfig("development")
 
     const devServer = new WebpackDevServer(compiler, devServerConfig);
 
-    const devServerUrl = `${devServerConfig.https ? 'https' : 'http'}://${devServerConfig.host}:${devServerConfig.port}`;
+    const devServerUrl = `http${devServerConfig.https ? "s" : ""}://${devServerConfig.host}:${devServerConfig.port}`;
 
 
     // Launch WebpackDevServer.

--- a/packages/pv-scripts/scripts/dev.js
+++ b/packages/pv-scripts/scripts/dev.js
@@ -37,6 +37,9 @@ prepareWebpackConfig("development")
 
     const devServer = new WebpackDevServer(compiler, devServerConfig);
 
+    const devServerUrl = `${devServerConfig.https ? 'https' : 'http'}://${devServerConfig.host}:${devServerConfig.port}`;
+
+
     // Launch WebpackDevServer.
     devServer.listen(devServerConfig.port, devServerConfig.host, err => {
       if (err) {
@@ -46,7 +49,7 @@ prepareWebpackConfig("development")
         clearConsole();
       }
 
-      console.log(chalk.cyan(`Starting the development server: http://${devServerConfig.host}:${devServerConfig.port}\n`));
+      console.log(chalk.cyan(`Starting the development server: ${devServerUrl}\n`));
     });
 
     ["SIGINT", "SIGTERM"].forEach(sig => {

--- a/packages/pv-scripts/scripts/dev.js
+++ b/packages/pv-scripts/scripts/dev.js
@@ -38,7 +38,7 @@ prepareWebpackConfig("development")
     const devServer = new WebpackDevServer(compiler, devServerConfig);
 
     // Launch WebpackDevServer.
-    devServer.listen(devServerConfig.port, "0.0.0.0", err => {
+    devServer.listen(devServerConfig.port, devServerConfig.host, err => {
       if (err) {
         return console.log(err);
       }
@@ -46,7 +46,7 @@ prepareWebpackConfig("development")
         clearConsole();
       }
 
-      console.log(chalk.cyan(`Starting the development server on port ${devServerConfig.port}...\n`));
+      console.log(chalk.cyan(`Starting the development server: http://${devServerConfig.host}:${devServerConfig.port}\n`));
     });
 
     ["SIGINT", "SIGTERM"].forEach(sig => {


### PR DESCRIPTION
== Description ==
In (before unknown) addition to https://github.com/pro-vision/fe-tools/commit/0e12d790f6f91fb7d53e6bd511bfc341167e26f4

Had the same idea, because I was also confused when I switched a lot between diefferent projects. But my proposal is to output the full url to get a clickable link in some terminals.

Further the hostname is currently hardcoded, and config changes wouldnt have any effect.

== Affected Packages ==
pv-scripts
