### PR TITLE
yaml support added

### DIFF
--- a/packages/assemble-lite/README.md
+++ b/packages/assemble-lite/README.md
@@ -18,7 +18,12 @@ assembleLite({
   partials: 'src/components/**/*.hbs',
   pages: 'src/pages/**/*.hbs',
   templates: 'src/templates/**/*.hbs',
-  data: ['src/components/**/*.json', 'src/templates/**/*.json'],
+  data: [
+    'src/components/**/*.json',
+    'src/components/**/*.yaml',
+    'src/templates/**/*.json',
+    'src/templates/**/*.yaml'
+  ],
   helpers: 'src/helpers/*.js',
   target: 'target/pages',
 }).then(() => {
@@ -34,6 +39,6 @@ assembleLite({
 | partials  | glob \| glob[]  | where are the partials                    |
 | pages     | glob \| glob[]  | where are the pages                       |
 | templates | glob \| glob[]  | where are the templates                   |
-| data      | glob \| glob[]  | where is the data (at the moment only .json files are supported)                        |
+| data      | glob \| glob[]  | where is the data                         |
 | helpers   | glob \| glob[]  | where are the custom handlebars-helpers (the collection from [handlebars-helpers](https://www.npmjs.com/package/handlebars-helpers) is already included - out of the box)                   |
 | target        | glob \| glob[]  | defines, where to put the rendered files  |

--- a/packages/assemble-lite/README.md
+++ b/packages/assemble-lite/README.md
@@ -22,7 +22,7 @@ assembleLite({
     'src/components/**/*.json',
     'src/components/**/*.yaml',
     'src/templates/**/*.json',
-    'src/templates/**/*.yaml'
+    'src/templates/**/*.yml'
   ],
   helpers: 'src/helpers/*.js',
   target: 'target/pages',

--- a/packages/assemble-lite/helper/data-helper.js
+++ b/packages/assemble-lite/helper/data-helper.js
@@ -13,7 +13,8 @@ const loadData = async data => {
 
     if (ext === ".json") {
       dataPool[filename] = await readJson(path);
-    } else if (ext === ".yaml" || ext === ".yml") {
+    }
+    else if (ext === ".yaml" || ext === ".yml") {
       dataPool[filename] = safeLoad(await readFile(path, "utf-8"), { filename });
     }
   }));

--- a/packages/assemble-lite/helper/data-helper.js
+++ b/packages/assemble-lite/helper/data-helper.js
@@ -1,5 +1,6 @@
-const { basename } = require("path");
-const { readJson } = require("fs-extra");
+const { basename, extname } = require("path");
+const { readJson, readFile } = require("fs-extra");
+const { safeLoad } = require("js-yaml");
 
 const { getPaths } = require("./io-helper");
 
@@ -7,9 +8,14 @@ const loadData = async data => {
   const dataPool = {};
   const dataPaths = await getPaths(data);
   await Promise.all(dataPaths.map(async path => {
-    const filename = basename(path, ".json");
-    const curData = await readJson(path);
-    dataPool[filename] = curData;
+    const ext = extname(path);
+    const filename = basename(path, ext);
+
+    if (ext === ".json") {
+      dataPool[filename] = await readJson(path);
+    } else if (ext === ".yaml" || ext === ".yml") {
+      dataPool[filename] = safeLoad(await readFile(path, "utf-8"), { filename });
+    }
   }));
   return dataPool;
 };

--- a/packages/assemble-lite/package-lock.json
+++ b/packages/assemble-lite/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pro-vision/assemble-lite",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1075,7 +1075,7 @@
     },
     "js-yaml": {
       "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "resolved": "https://nexus3.pvtool.org/repository/npm-default/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "requires": {
         "argparse": "^1.0.7",

--- a/packages/assemble-lite/package.json
+++ b/packages/assemble-lite/package.json
@@ -32,6 +32,7 @@
     "glob": "7.1.6",
     "handlebars": "4.5.3",
     "handlebars-helpers": "0.10.0",
+    "js-yaml": "3.13.1",
     "yaml-front-matter": "4.0.0"
   }
 }

--- a/packages/pv-stylemark/gulp-tasks/clickdummy_tasks/assembleClickdummyComponents.js
+++ b/packages/pv-stylemark/gulp-tasks/clickdummy_tasks/assembleClickdummyComponents.js
@@ -4,13 +4,19 @@ const { resolveApp, getAppConfig, join } = require("../../helper/paths");
 
 const {destPath, cdTemplatesSrc, componentsSrc, hbsHelperSrc} = getAppConfig();
 
+function *composeDataPaths(...fileExtensions) {
+  for (const ext of fileExtensions) {
+    yield resolveApp(join(componentsSrc, `**/*.${ext}`));
+    yield resolveApp(join(cdTemplatesSrc, `*.${ext}`));
+  }
+}
 
 const assembleClickdummyComponents = () => assemble({
   baseDir: resolveApp(componentsSrc),
   partials: resolveApp(join(componentsSrc, "**/*.hbs")),
   pages: resolveApp(join(componentsSrc, "**/*.hbs")),
   templates: resolveApp(join(cdTemplatesSrc, "**/*.hbs")),
-  data: [resolveApp(join(componentsSrc, "**/*.json")), resolveApp(join(cdTemplatesSrc, "*.json"))],
+  data: [...composeDataPaths("json", "yaml", "yml")],
   helpers: resolveApp(join(hbsHelperSrc, "*.js")),
   target: resolveApp(join(destPath, "components"))
 });

--- a/packages/pv-stylemark/gulp-tasks/clickdummy_tasks/assembleClickdummyPages.js
+++ b/packages/pv-stylemark/gulp-tasks/clickdummy_tasks/assembleClickdummyPages.js
@@ -10,7 +10,11 @@ const assembleClickdummyPages = () => assemble({
   partials: resolveApp(join(componentsSrc, "**/*.hbs")),
   pages: resolveApp(join(cdPagesSrc, "**/*.hbs")),
   templates: resolveApp(join(cdTemplatesSrc, "**/*.hbs")),
-  data: resolveApp(join(componentsSrc, "**/*.json")),
+  data: [
+    resolveApp(join(componentsSrc, "**/*.json")),
+    resolveApp(join(componentsSrc, "**/*.yaml")),
+    resolveApp(join(componentsSrc, "**/*.yml"))
+  ],
   helpers: resolveApp(join(hbsHelperSrc, "*.js")),
   target: resolveApp(join(destPath, "pages"))
 });

--- a/packages/pv-stylemark/gulp-tasks/lsg_tasks/assembleLSGComponents.js
+++ b/packages/pv-stylemark/gulp-tasks/lsg_tasks/assembleLSGComponents.js
@@ -9,7 +9,11 @@ const assembleLSGComponents = () => assemble({
   partials: resolveApp(join(componentsSrc, "**/*.hbs")),
   pages: resolveApp(join(componentsSrc, "**/*.hbs")),
   templates: resolveApp(join(lsgTemplatesSrc, "**/*.hbs")),
-  data: resolveApp(join(componentsSrc, "**/*.json")),
+  data: [
+    resolveApp(join(componentsSrc, "**/*.json")),
+    resolveApp(join(componentsSrc, "**/*.yaml")),
+    resolveApp(join(componentsSrc, "**/*.yml"))
+  ],
   helpers: resolveApp(join(hbsHelperSrc, "*.js")),
   target: resolveApp(join(destPath, "/lsg_components"))
 });

--- a/packages/pv-stylemark/scripts/dev.js
+++ b/packages/pv-stylemark/scripts/dev.js
@@ -31,14 +31,12 @@ const watchFiles = () => {
   gulp.watch(join(cdPagesSrc, "**/*.hbs"), gulp.series(recompileMessage, assembleClickdummyPages, recompiledMessage));
   gulp.watch(join(lsgAssetsSrc, "**/*.*"), gulp.series(recompileMessage, copyStyleguideFiles, recompiledMessage));
   gulp.watch(lsgIndex, gulp.series(recompileMessage, copyClickdummyFiles, recompiledMessage));
-  gulp.watch(
-    join(componentsSrc, "**/*.hbs"),
-    gulp.series(recompileMessage, assembleClickdummyComponents, assembleClickdummyPages, assembleLSGComponents, buildStylemark, recompiledMessage)
-  );
-  gulp.watch(
-    join(componentsSrc, "**/*.json"),
-    gulp.series(recompileMessage, assembleClickdummyComponents, assembleClickdummyPages, assembleLSGComponents, buildStylemark, recompiledMessage)
-  );
+  for (const ext of ["hbs", "json", "yaml", "yml"]) {
+    gulp.watch(
+      join(componentsSrc, `**/*.${ext}`),
+      gulp.series(recompileMessage, assembleClickdummyComponents, assembleClickdummyPages, assembleLSGComponents, buildStylemark, recompiledMessage)
+    );
+  }
 };
 
 const build = done => gulp.series(buildClickdummy, buildLSG)(done);

--- a/packages/pv-stylemark/webpack-plugin/getFilesToWatch.js
+++ b/packages/pv-stylemark/webpack-plugin/getFilesToWatch.js
@@ -13,6 +13,10 @@ const getFilesToWatch = async () => {
   // add .json Components files
   files.push(...await asyncGlob(join(componentsSrc, "**/*.json")));
 
+  // add .yaml/.yml Component files
+  files.push(...await asyncGlob(join(componentsSrc, "**/*.yaml")));
+  files.push(...await asyncGlob(join(componentsSrc, "**/*.yml")));
+
   // add .hbs Components files
   files.push(...await asyncGlob(join(componentsSrc, "**/*.hbs")));
 


### PR DESCRIPTION
== Description ==
- YAML (*.yaml, *.yml) support added to `assemble-lite` package. YAML content is added to the `dataPool` similar to the already existing JSON functionality.
- Glob patterns inside the `pv-stylemark` package update to support YAML format.

== Affected Packages ==
- assemble-lite
- pv-stylemark