### PR TITLE
postcss preset env: ltr as default

### DIFF
--- a/packages/webpack-config/src/webpack/dev/tasks/compileCSS/legacy.js
+++ b/packages/webpack-config/src/webpack/dev/tasks/compileCSS/legacy.js
@@ -17,7 +17,14 @@ export const legacyCompileCSS = {
             loader: require.resolve("postcss-loader"),
             options: {
               ident: "postcss",
-              plugins: () => [require("postcss-preset-env"), require("cssnano")]
+              plugins: () => [
+                require("postcss-preset-env")({
+                  features: {
+                    'dir-pseudo-class': { dir: 'ltr' }
+                  }
+                }),
+                require("cssnano")
+              ]
             }
           },
           {

--- a/packages/webpack-config/src/webpack/dev/tasks/compileCSS/legacy.js
+++ b/packages/webpack-config/src/webpack/dev/tasks/compileCSS/legacy.js
@@ -20,7 +20,7 @@ export const legacyCompileCSS = {
               plugins: () => [
                 require("postcss-preset-env")({
                   features: {
-                    'dir-pseudo-class': { dir: 'ltr' }
+                    "dir-pseudo-class": { dir: "ltr" }
                   }
                 }),
                 require("cssnano")

--- a/packages/webpack-config/src/webpack/dev/tasks/compileCSS/module.js
+++ b/packages/webpack-config/src/webpack/dev/tasks/compileCSS/module.js
@@ -21,7 +21,7 @@ export const moduleCompileCSS = {
               plugins: () => [
                 require("postcss-preset-env")({
                   features: {
-                    'dir-pseudo-class': { dir: 'ltr' }
+                    "dir-pseudo-class": { dir: "ltr" }
                   }
                 }),
                 require("cssnano")

--- a/packages/webpack-config/src/webpack/dev/tasks/compileCSS/module.js
+++ b/packages/webpack-config/src/webpack/dev/tasks/compileCSS/module.js
@@ -18,7 +18,14 @@ export const moduleCompileCSS = {
             loader: require.resolve("postcss-loader"),
             options: {
               ident: "postcss",
-              plugins: () => [require("postcss-preset-env"), require("cssnano")]
+              plugins: () => [
+                require("postcss-preset-env")({
+                  features: {
+                    'dir-pseudo-class': { dir: 'ltr' }
+                  }
+                }),
+                require("cssnano")
+              ]
             }
           },
           {

--- a/packages/webpack-config/src/webpack/prod/tasks/compileCSS.js
+++ b/packages/webpack-config/src/webpack/prod/tasks/compileCSS.js
@@ -17,7 +17,11 @@ export const compileCSS = {
             options: {
               ident: "postcss",
               plugins: () => [
-                require("postcss-preset-env"),
+                require("postcss-preset-env")({
+                  features: {
+                    'dir-pseudo-class': { dir: 'ltr' }
+                  }
+                }),
                 require("cssnano"),
               ],
             }

--- a/packages/webpack-config/src/webpack/prod/tasks/compileCSS.js
+++ b/packages/webpack-config/src/webpack/prod/tasks/compileCSS.js
@@ -19,7 +19,7 @@ export const compileCSS = {
               plugins: () => [
                 require("postcss-preset-env")({
                   features: {
-                    'dir-pseudo-class': { dir: 'ltr' }
+                    "dir-pseudo-class": { dir: "ltr" }
                   }
                 }),
                 require("cssnano"),


### PR DESCRIPTION
== Description ==

The included postcss already transpiles logical CSS properties (e.g. `margin-inline`) into 'older' CSS. By default **postcss-logical** requires a `dir` Attribute in one of the parent elements for the generated rules to work. But usually `dir="ltr"` is implicit and not explicitly set in the `html` tag (or any of its descendants). Fortunately, **postcss-logical** lets us define a default...

https://github.com/csstools/postcss-logical

== Affected Packages ==

webpack-config
