### PR TITLE
webpack-config handlebars-loader options

### DIFF
--- a/packages/pv-scripts/README.md
+++ b/packages/pv-scripts/README.md
@@ -57,7 +57,7 @@ Basic Configuration can be done in a `pv.config.js` file in the npm project root
 | cleanDest       | boolean | false                | defines whether the destination folder should be cleaned before every pv-scripts run                            |
 | fontsSrc        | string  | "resources/fonts/"   | defines folder in which the fonts are located                                                                   |
 | resourcesSrc    | string  | "resources"           | defines resources folder which is copied to target/resources                                                   |
-| autoConsoleClear | boolean  | false"              | defines whether the console should be cleared automatically in dev-mode                                        |
+| autoConsoleClear | boolean  | "false"              | defines whether the console should be cleared automatically in dev-mode                                        |
 
 ##### Example:
 

--- a/packages/pv-scripts/README.md
+++ b/packages/pv-scripts/README.md
@@ -11,7 +11,7 @@ npm i @pro-vision/pv-scripts -D
 ## Usage
 
 ### Requirements
-To use the CLI, you need to create at least the two entry-files (`jsEntry`, `jsLegacyEntry`), see [Basic Configuration](#Basic Configuration)).
+To use the CLI, you need to create at least the two entry-files (`jsEntry`, `jsLegacyEntry`), see [Basic Configuration](#basic-configuration).
 
 ### Command Line Interface
 
@@ -19,15 +19,19 @@ Installing this package gives you the CLI `pv-scripts`. It can be used with the 
 
 To run a locally installed version of the `pv-scripts`, you can either call the `pv-scripts` command directly from your local `node_modules/.bin` folder or by using npx.
 
+**dev:**
+Transpiles and bundles your code (JS/TS/JSX/TSX/SCSS) via `webpack` (+ all needed loaders) and opens a `webpack-dev-server` on the configured port (default: 8616).
+
 ```sh
 npx pv-scripts dev
 ```
 
-**dev:**
-Transpiles and bundles your code (JS/TS/JSX/TSX/SCSS) via `webpack` (+ all needed loaders) and opens a `webpack-dev-server` on the configured port (default: 8616).
-
 **prod:**
 Transpiles and bundles your code (JS/TS/JSX/TSX/SCSS) via `webpack` (+ all needed loaders) and writes them to your target folder.
+
+```sh
+npx pv-scripts prod
+```
 
 ### Configuration
 
@@ -38,11 +42,12 @@ Basic Configuration can be done in a `pv.config.js` file in the npm project root
 | key             | type    | default              | usage                                                                                                           |
 | --------------- | ------- | -------------------- | --------------------------------------------------------------------------------------------------------------- |
 | devServerPort   | number  | 8616                 | set `webpack-dev-server` port                                                                                   |
+| srcPath         | string  | "src"                | defines the working directory                                                                                   |
 | destPath        | string  | "target"             | defines where to put bundled files                                                                              |
-| namespace       | string  |                      | this controls the name-prefix on your bundled files following this pattern `[namespace].app.[?legacy].(js|css)` |
+| namespace       | string  | ""                   | this controls the name-prefix on your bundled files following this pattern `[namespace].app.[?legacy].(js|css)` |
 | jsEntry         | string  | "src/index.ts"       | defines path of your (JS\|TS\|JSX\|TSX) entry file                                                              |
 | jsLegacyEntry   | string  | "src/legacyIndex.ts" | defines path of your (JS\|TS\|JSX\|TSX) legacy entry file                                                       |
-| cssEntry        | string  | "src/index.scss"     | defines path of your SCSS entry file. If `src/index.scss` does not exist, no error is thrown but the css generation is simply skipped                                                                           |
+| cssEntry        | string  | "src/index.scss"     | defines path of your SCSS entry file. If `src/index.scss` does not exist, no error is thrown but the css generation is simply skipped|
 | useTS           | boolean | true                 | defines whether you want to use Typescript                                                                      |
 | useReact        | boolean | false                | defines whether you want to use React                                                                           |
 | hbsEntry        | string  |                      | defines path of your handlebars entry file                                                                      |
@@ -51,8 +56,8 @@ Basic Configuration can be done in a `pv.config.js` file in the npm project root
 | copyStaticFiles | boolean | false                | defines whether content of `/static` should be copied to target                                                 |
 | cleanDest       | boolean | false                | defines whether the destination folder should be cleaned before every pv-scripts run                            |
 | fontsSrc        | string  | "resources/fonts/"   | defines folder in which the fonts are located                                                                   |
-| resourcesSrc    | string  | "resources"           | defines resources folder which is copied to target/resources                                                    |
-| autoConsoleClear | boolean  | false"              | defines whether the console should be cleared automatically in dev-mode                                                |
+| resourcesSrc    | string  | "resources"           | defines resources folder which is copied to target/resources                                                   |
+| autoConsoleClear | boolean  | false"              | defines whether the console should be cleared automatically in dev-mode                                        |
 
 ##### Example:
 
@@ -62,7 +67,7 @@ module.exports = {
   devServerPort: 8616,
   destPath: "target",
   jsEntry: "src/index.js",
-  jsLegacyEntry: "src/index.js",
+  jsLegacyEntry: "src/legacyIndex.js",
   cssEntry: "src/index.scss",
   useTS: false,
   useReact: false,

--- a/packages/pv-scripts/README.md
+++ b/packages/pv-scripts/README.md
@@ -47,7 +47,7 @@ Basic Configuration can be done in a `pv.config.js` file in the npm project root
 | useReact        | boolean | false                | defines whether you want to use React                                                                           |
 | hbsEntry        | string  |                      | defines path of your handlebars entry file                                                                      |
 | hbsTarget       | string  |                      | defines path to your handlebars target file                                                                     |
-| hbsPartialDir   | string  |                      | defines path to your a handlebars partials directory                                                            |
+| handlebarsLoaderOptions   | string  |            | Object with additional options for the `handlebars-loader`. See https://github.com/pcardune/handlebars-loader for these options. Paths are relative to `pv.config.js`                                                       |
 | copyStaticFiles | boolean | false                | defines whether content of `/static` should be copied to target                                                 |
 | cleanDest       | boolean | false                | defines whether the destination folder should be cleaned before every pv-scripts run                            |
 | fontsSrc        | string  | "resources/fonts/"   | defines folder in which the fonts are located                                                                   |

--- a/packages/pv-scripts/README.md
+++ b/packages/pv-scripts/README.md
@@ -47,7 +47,7 @@ Basic Configuration can be done in a `pv.config.js` file in the npm project root
 | useReact        | boolean | false                | defines whether you want to use React                                                                           |
 | hbsEntry        | string  |                      | defines path of your handlebars entry file                                                                      |
 | hbsTarget       | string  |                      | defines path to your handlebars target file                                                                     |
-| handlebarsLoaderOptions   | string  |            | Object with additional options for the `handlebars-loader`. See https://github.com/pcardune/handlebars-loader for these options. Paths are relative to `pv.config.js`                                                       |
+| handlebarsLoaderOptions   | string  | {}         | Object with additional options for the `handlebars-loader`. See https://github.com/pcardune/handlebars-loader for these options. Paths are relative to `pv.config.js`                                                       |
 | copyStaticFiles | boolean | false                | defines whether content of `/static` should be copied to target                                                 |
 | cleanDest       | boolean | false                | defines whether the destination folder should be cleaned before every pv-scripts run                            |
 | fontsSrc        | string  | "resources/fonts/"   | defines folder in which the fonts are located                                                                   |

--- a/packages/webpack-config/src/config/default.config.js
+++ b/packages/webpack-config/src/config/default.config.js
@@ -13,5 +13,6 @@ export const defaultConfig = {
   enableTypeCheck: true,
   fontsSrc: "resources/fonts/",
   resourcesSrc: "resources",
-  autoConsoleClear: false
+  autoConsoleClear: false,
+  handlebarsLoaderOptions: {},
 };

--- a/packages/webpack-config/src/helpers/paths.js
+++ b/packages/webpack-config/src/helpers/paths.js
@@ -117,10 +117,20 @@ export function join(...paths) {
 export const useHtmlCompiler = Boolean(config.hbsEntry && config.hbsTarget);
 export const hbsEntry = useHtmlCompiler ? resolveApp(config.hbsEntry) : "/";
 export const hbsTarget = useHtmlCompiler ? resolveApp(config.hbsTarget) : "/";
-// check if a hbs partial dir is provided
-export const hbsPartialDir = {
-  partialDirs: config.hbsPartialDir ? [resolveApp(config.hbsPartialDir)] : []
-};
+
+/******************************************************************************
+ ** handlerbars-loader options
+ ******************************************************************************/
+const handlebarsLoaderOptions = config.handlebarsLoaderOptions || {};
+// expect paths to be relative to ov.config.js similar to the other configurations. and convert to absolute paths
+// helperDirs
+if (handlebarsLoaderOptions.helperDirs) handlebarsLoaderOptions.helperDirs = handlebarsLoaderOptions.helperDirs.map(resolveApp);
+// partialDirs
+if (handlebarsLoaderOptions.partialDirs) handlebarsLoaderOptions.partialDirs = handlebarsLoaderOptions.partialDirs.map(resolveApp);
+// runtime
+if (handlebarsLoaderOptions.runtime) handlebarsLoaderOptions.runtime = resolveApp(handlebarsLoaderOptions.runtime);
+
+export { handlebarsLoaderOptions };
 
 /******************************************************************************
  ** EOD CompileHTML helper

--- a/packages/webpack-config/src/helpers/paths.js
+++ b/packages/webpack-config/src/helpers/paths.js
@@ -121,7 +121,7 @@ export const hbsTarget = useHtmlCompiler ? resolveApp(config.hbsTarget) : "/";
 /******************************************************************************
  ** handlerbars-loader options
  ******************************************************************************/
-const handlebarsLoaderOptions = config.handlebarsLoaderOptions || {};
+const handlebarsLoaderOptions = config.handlebarsLoaderOptions;
 // expect paths to be relative to ov.config.js similar to the other configurations. and convert to absolute paths
 // helperDirs
 if (handlebarsLoaderOptions.helperDirs) handlebarsLoaderOptions.helperDirs = handlebarsLoaderOptions.helperDirs.map(resolveApp);

--- a/packages/webpack-config/src/webpack/base/tasks/loadHandlebars.js
+++ b/packages/webpack-config/src/webpack/base/tasks/loadHandlebars.js
@@ -1,4 +1,4 @@
-import { hbsPartialDir as options } from "../../../helpers/paths";
+import { handlebarsLoaderOptions as options } from "../../../helpers/paths";
 
 export const loadHandlebars = {
   module: {

--- a/packages/webpack-config/src/webpack/prod/tasks/compileCSS.js
+++ b/packages/webpack-config/src/webpack/prod/tasks/compileCSS.js
@@ -22,7 +22,15 @@ export const compileCSS = {
                     "dir-pseudo-class": { dir: "ltr" }
                   }
                 }),
-                require("cssnano"),
+                require("cssnano")({
+                  preset: ["default", {
+                    // Prevent conversion of colors to smallest representation, to avoid problems
+                    // when converting `rgba(255, 255, 255, opacity)` to `hsla(0,0%,100%, opacity)`.
+                    // The compressor in AEM strips the `%` from the `0%` saturation value,
+                    // resulting in an invalid property value.
+                    colormin: false,
+                  }]
+                }),
               ],
             }
           },


### PR DESCRIPTION
== Description ==
read options for the webpacks handlerbars-loader from pv.config and convert relative paths to absolute paths,
remove `hbsPartialDir` in favor of `handlebarsLoaderOptions`


== Closes issue(s) ==
not being able to bundle handlebarsHelpers

== Changes ==
pv.config.js's `hbsPartialDir` option with `handlebarsLoaderOptions` 

== Affected Packages ==
webpack-config