### PR TITLE
Feature/babel setup decorator and class property

### DIFF
--- a/packages/pv-scripts/README.md
+++ b/packages/pv-scripts/README.md
@@ -47,7 +47,7 @@ Basic Configuration can be done in a `pv.config.js` file in the npm project root
 | useReact        | boolean | false                | defines whether you want to use React                                                                           |
 | hbsEntry        | string  |                      | defines path of your handlebars entry file                                                                      |
 | hbsTarget       | string  |                      | defines path to your handlebars target file                                                                     |
-| hbsPartialDir   | string  |                      | defines path to your a handlebars partials directory                                                            |
+| handlebarsLoaderOptions   | string  |            | Object with additional options for the `handlebars-loader`. See https://github.com/pcardune/handlebars-loader for these options. Paths are relative to `pv.config.js`                                                       |
 | copyStaticFiles | boolean | false                | defines whether content of `/static` should be copied to target                                                 |
 | cleanDest       | boolean | false                | defines whether the destination folder should be cleaned before every pv-scripts run                            |
 | fontsSrc        | string  | "resources/fonts/"   | defines folder in which the fonts are located                                                                   |

--- a/packages/pv-scripts/README.md
+++ b/packages/pv-scripts/README.md
@@ -47,7 +47,7 @@ Basic Configuration can be done in a `pv.config.js` file in the npm project root
 | useReact        | boolean | false                | defines whether you want to use React                                                                           |
 | hbsEntry        | string  |                      | defines path of your handlebars entry file                                                                      |
 | hbsTarget       | string  |                      | defines path to your handlebars target file                                                                     |
-| handlebarsLoaderOptions   | string  |            | Object with additional options for the `handlebars-loader`. See https://github.com/pcardune/handlebars-loader for these options. Paths are relative to `pv.config.js`                                                       |
+| handlebarsLoaderOptions   | string  | {}         | Object with additional options for the `handlebars-loader`. See https://github.com/pcardune/handlebars-loader for these options. Paths are relative to `pv.config.js`                                                       |
 | copyStaticFiles | boolean | false                | defines whether content of `/static` should be copied to target                                                 |
 | cleanDest       | boolean | false                | defines whether the destination folder should be cleaned before every pv-scripts run                            |
 | fontsSrc        | string  | "resources/fonts/"   | defines folder in which the fonts are located                                                                   |

--- a/packages/webpack-config/src/config/default.config.js
+++ b/packages/webpack-config/src/config/default.config.js
@@ -13,5 +13,6 @@ export const defaultConfig = {
   enableTypeCheck: true,
   fontsSrc: "resources/fonts/",
   resourcesSrc: "resources",
-  autoConsoleClear: false
+  autoConsoleClear: false,
+  handlebarsLoaderOptions: {},
 };

--- a/packages/webpack-config/src/helpers/paths.js
+++ b/packages/webpack-config/src/helpers/paths.js
@@ -117,10 +117,20 @@ export function join(...paths) {
 export const useHtmlCompiler = Boolean(config.hbsEntry && config.hbsTarget);
 export const hbsEntry = useHtmlCompiler ? resolveApp(config.hbsEntry) : "/";
 export const hbsTarget = useHtmlCompiler ? resolveApp(config.hbsTarget) : "/";
-// check if a hbs partial dir is provided
-export const hbsPartialDir = {
-  partialDirs: config.hbsPartialDir ? [resolveApp(config.hbsPartialDir)] : []
-};
+
+/******************************************************************************
+ ** handlerbars-loader options
+ ******************************************************************************/
+const handlebarsLoaderOptions = config.handlebarsLoaderOptions || {};
+// expect paths to be relative to ov.config.js similar to the other configurations. and convert to absolute paths
+// helperDirs
+if (handlebarsLoaderOptions.helperDirs) handlebarsLoaderOptions.helperDirs = handlebarsLoaderOptions.helperDirs.map(resolveApp);
+// partialDirs
+if (handlebarsLoaderOptions.partialDirs) handlebarsLoaderOptions.partialDirs = handlebarsLoaderOptions.partialDirs.map(resolveApp);
+// runtime
+if (handlebarsLoaderOptions.runtime) handlebarsLoaderOptions.runtime = resolveApp(handlebarsLoaderOptions.runtime);
+
+export { handlebarsLoaderOptions };
 
 /******************************************************************************
  ** EOD CompileHTML helper

--- a/packages/webpack-config/src/helpers/paths.js
+++ b/packages/webpack-config/src/helpers/paths.js
@@ -121,7 +121,7 @@ export const hbsTarget = useHtmlCompiler ? resolveApp(config.hbsTarget) : "/";
 /******************************************************************************
  ** handlerbars-loader options
  ******************************************************************************/
-const handlebarsLoaderOptions = config.handlebarsLoaderOptions || {};
+const handlebarsLoaderOptions = config.handlebarsLoaderOptions;
 // expect paths to be relative to ov.config.js similar to the other configurations. and convert to absolute paths
 // helperDirs
 if (handlebarsLoaderOptions.helperDirs) handlebarsLoaderOptions.helperDirs = handlebarsLoaderOptions.helperDirs.map(resolveApp);

--- a/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileES/legacy.js
+++ b/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileES/legacy.js
@@ -39,7 +39,7 @@ export const legacyCompileES = {
                 ],
                 require.resolve("@babel/plugin-transform-async-to-generator"),
                 require.resolve("@babel/plugin-syntax-dynamic-import"),
-                require.resolve("@babel/plugin-proposal-class-properties"),
+                [require.resolve("@babel/plugin-proposal-class-properties"), { loose: true }],
                 require.resolve("@babel/plugin-proposal-object-rest-spread")
               ]
             }

--- a/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileES/module.js
+++ b/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileES/module.js
@@ -40,7 +40,7 @@ export const moduleCompileES = {
                   }
                 ],
                 require.resolve("@babel/plugin-syntax-dynamic-import"),
-                require.resolve("@babel/plugin-proposal-class-properties"),
+                [require.resolve("@babel/plugin-proposal-class-properties"), { loose: true }],
                 require.resolve("@babel/plugin-proposal-object-rest-spread")
               ]
             }

--- a/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileJSX/legacy.js
+++ b/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileJSX/legacy.js
@@ -26,7 +26,7 @@ export const legacyCompileJSX = {
                     legacy: true
                   }
                 ],
-                require.resolve("@babel/plugin-proposal-class-properties"),
+                [require.resolve("@babel/plugin-proposal-class-properties"), { loose: true }],
                 require.resolve("@babel/plugin-transform-arrow-functions"),
                 require.resolve("@babel/plugin-syntax-dynamic-import"),
                 require.resolve("@babel/plugin-syntax-import-meta"),

--- a/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileJSX/module.js
+++ b/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileJSX/module.js
@@ -20,17 +20,17 @@ export const moduleCompileJSX = {
                 require.resolve("@babel/preset-react")
               ],
               plugins: [
-                require.resolve("@babel/plugin-proposal-class-properties"),
-                require.resolve("@babel/plugin-transform-arrow-functions"),
-                require.resolve("@babel/plugin-syntax-dynamic-import"),
-                require.resolve("@babel/plugin-syntax-import-meta"),
-                require.resolve("@babel/plugin-proposal-json-strings"),
                 [
                   require.resolve("@babel/plugin-proposal-decorators"),
                   {
                     legacy: true
                   }
                 ],
+                [require.resolve("@babel/plugin-proposal-class-properties"), { loose: true }],
+                require.resolve("@babel/plugin-transform-arrow-functions"),
+                require.resolve("@babel/plugin-syntax-dynamic-import"),
+                require.resolve("@babel/plugin-syntax-import-meta"),
+                require.resolve("@babel/plugin-proposal-json-strings"),
                 require.resolve("@babel/plugin-proposal-function-sent"),
                 require.resolve("@babel/plugin-proposal-export-namespace-from"),
                 require.resolve("@babel/plugin-proposal-numeric-separator"),

--- a/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileTS/legacy.js
+++ b/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileTS/legacy.js
@@ -42,7 +42,7 @@ export const legacyCompileTS = {
                 ],
                 require.resolve("@babel/plugin-transform-async-to-generator"),
                 require.resolve("@babel/plugin-syntax-dynamic-import"),
-                require.resolve("@babel/plugin-proposal-class-properties"),
+                [require.resolve("@babel/plugin-proposal-class-properties"), { loose: true }],
                 require.resolve("@babel/plugin-proposal-object-rest-spread")
               ]
             }

--- a/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileTS/module.js
+++ b/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileTS/module.js
@@ -41,7 +41,7 @@ export const moduleCompileTS = {
                   }
                 ],
                 require.resolve("@babel/plugin-syntax-dynamic-import"),
-                require.resolve("@babel/plugin-proposal-class-properties"),
+                [require.resolve("@babel/plugin-proposal-class-properties"), { loose: true }],
                 require.resolve("@babel/plugin-proposal-object-rest-spread")
               ]
             }

--- a/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileTSX/legacy.js
+++ b/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileTSX/legacy.js
@@ -27,7 +27,7 @@ export const legacyCompileTSX = {
                     legacy: true
                   }
                 ],
-                require.resolve("@babel/plugin-proposal-class-properties"),
+                [require.resolve("@babel/plugin-proposal-class-properties"), { loose: true }],
                 require.resolve("@babel/plugin-transform-arrow-functions"),
                 require.resolve("@babel/plugin-syntax-dynamic-import"),
                 require.resolve("@babel/plugin-syntax-import-meta"),

--- a/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileTSX/module.js
+++ b/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileTSX/module.js
@@ -21,17 +21,17 @@ export const moduleCompileTSX = {
                 require.resolve("@babel/preset-typescript")
               ],
               plugins: [
-                require.resolve("@babel/plugin-proposal-class-properties"),
-                require.resolve("@babel/plugin-transform-arrow-functions"),
-                require.resolve("@babel/plugin-syntax-dynamic-import"),
-                require.resolve("@babel/plugin-syntax-import-meta"),
-                require.resolve("@babel/plugin-proposal-json-strings"),
                 [
                   require.resolve("@babel/plugin-proposal-decorators"),
                   {
                     legacy: true
                   }
                 ],
+                [require.resolve("@babel/plugin-proposal-class-properties"), { loose: true }],
+                require.resolve("@babel/plugin-transform-arrow-functions"),
+                require.resolve("@babel/plugin-syntax-dynamic-import"),
+                require.resolve("@babel/plugin-syntax-import-meta"),
+                require.resolve("@babel/plugin-proposal-json-strings"),
                 require.resolve("@babel/plugin-proposal-function-sent"),
                 require.resolve("@babel/plugin-proposal-export-namespace-from"),
                 require.resolve("@babel/plugin-proposal-numeric-separator"),

--- a/packages/webpack-config/src/webpack/base/tasks/loadHandlebars.js
+++ b/packages/webpack-config/src/webpack/base/tasks/loadHandlebars.js
@@ -1,4 +1,4 @@
-import { hbsPartialDir as options } from "../../../helpers/paths";
+import { handlebarsLoaderOptions as options } from "../../../helpers/paths";
 
 export const loadHandlebars = {
   module: {


### PR DESCRIPTION
== Description ==
when using @babel/plugin-proposal-class-properties & @babel/plugin-proposal-decorators in combination, load decorator plugin first, and the class properties in loose mode when decorator is loaded in legacy mode to follow the babel documentation https://babeljs.io/docs/en/babel-plugin-proposal-decorators

== Closes issue(s) ==


== Changes ==
webpacks babel plugin order and options 

== Affected Packages ==
webpack-config