### PR TITLE
Babel Setup: when using @babel/plugin-proposal-class-properties & @ba…

### DIFF
--- a/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileES/legacy.js
+++ b/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileES/legacy.js
@@ -39,7 +39,7 @@ export const legacyCompileES = {
                 ],
                 require.resolve("@babel/plugin-transform-async-to-generator"),
                 require.resolve("@babel/plugin-syntax-dynamic-import"),
-                require.resolve("@babel/plugin-proposal-class-properties"),
+                [require.resolve("@babel/plugin-proposal-class-properties"), { loose: true }],
                 require.resolve("@babel/plugin-proposal-object-rest-spread")
               ]
             }

--- a/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileES/module.js
+++ b/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileES/module.js
@@ -40,7 +40,7 @@ export const moduleCompileES = {
                   }
                 ],
                 require.resolve("@babel/plugin-syntax-dynamic-import"),
-                require.resolve("@babel/plugin-proposal-class-properties"),
+                [require.resolve("@babel/plugin-proposal-class-properties"), { loose: true }],
                 require.resolve("@babel/plugin-proposal-object-rest-spread")
               ]
             }

--- a/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileJSX/legacy.js
+++ b/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileJSX/legacy.js
@@ -26,7 +26,7 @@ export const legacyCompileJSX = {
                     legacy: true
                   }
                 ],
-                require.resolve("@babel/plugin-proposal-class-properties"),
+                [require.resolve("@babel/plugin-proposal-class-properties"), { loose: true }],
                 require.resolve("@babel/plugin-transform-arrow-functions"),
                 require.resolve("@babel/plugin-syntax-dynamic-import"),
                 require.resolve("@babel/plugin-syntax-import-meta"),

--- a/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileJSX/module.js
+++ b/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileJSX/module.js
@@ -20,17 +20,17 @@ export const moduleCompileJSX = {
                 require.resolve("@babel/preset-react")
               ],
               plugins: [
-                require.resolve("@babel/plugin-proposal-class-properties"),
-                require.resolve("@babel/plugin-transform-arrow-functions"),
-                require.resolve("@babel/plugin-syntax-dynamic-import"),
-                require.resolve("@babel/plugin-syntax-import-meta"),
-                require.resolve("@babel/plugin-proposal-json-strings"),
                 [
                   require.resolve("@babel/plugin-proposal-decorators"),
                   {
                     legacy: true
                   }
                 ],
+                [require.resolve("@babel/plugin-proposal-class-properties"), { loose: true }],
+                require.resolve("@babel/plugin-transform-arrow-functions"),
+                require.resolve("@babel/plugin-syntax-dynamic-import"),
+                require.resolve("@babel/plugin-syntax-import-meta"),
+                require.resolve("@babel/plugin-proposal-json-strings"),
                 require.resolve("@babel/plugin-proposal-function-sent"),
                 require.resolve("@babel/plugin-proposal-export-namespace-from"),
                 require.resolve("@babel/plugin-proposal-numeric-separator"),

--- a/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileTS/legacy.js
+++ b/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileTS/legacy.js
@@ -42,7 +42,7 @@ export const legacyCompileTS = {
                 ],
                 require.resolve("@babel/plugin-transform-async-to-generator"),
                 require.resolve("@babel/plugin-syntax-dynamic-import"),
-                require.resolve("@babel/plugin-proposal-class-properties"),
+                [require.resolve("@babel/plugin-proposal-class-properties"), { loose: true }],
                 require.resolve("@babel/plugin-proposal-object-rest-spread")
               ]
             }

--- a/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileTS/module.js
+++ b/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileTS/module.js
@@ -41,7 +41,7 @@ export const moduleCompileTS = {
                   }
                 ],
                 require.resolve("@babel/plugin-syntax-dynamic-import"),
-                require.resolve("@babel/plugin-proposal-class-properties"),
+                [require.resolve("@babel/plugin-proposal-class-properties"), { loose: true }],
                 require.resolve("@babel/plugin-proposal-object-rest-spread")
               ]
             }

--- a/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileTSX/legacy.js
+++ b/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileTSX/legacy.js
@@ -27,7 +27,7 @@ export const legacyCompileTSX = {
                     legacy: true
                   }
                 ],
-                require.resolve("@babel/plugin-proposal-class-properties"),
+                [require.resolve("@babel/plugin-proposal-class-properties"), { loose: true }],
                 require.resolve("@babel/plugin-transform-arrow-functions"),
                 require.resolve("@babel/plugin-syntax-dynamic-import"),
                 require.resolve("@babel/plugin-syntax-import-meta"),

--- a/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileTSX/module.js
+++ b/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileTSX/module.js
@@ -21,17 +21,17 @@ export const moduleCompileTSX = {
                 require.resolve("@babel/preset-typescript")
               ],
               plugins: [
-                require.resolve("@babel/plugin-proposal-class-properties"),
-                require.resolve("@babel/plugin-transform-arrow-functions"),
-                require.resolve("@babel/plugin-syntax-dynamic-import"),
-                require.resolve("@babel/plugin-syntax-import-meta"),
-                require.resolve("@babel/plugin-proposal-json-strings"),
                 [
                   require.resolve("@babel/plugin-proposal-decorators"),
                   {
                     legacy: true
                   }
                 ],
+                [require.resolve("@babel/plugin-proposal-class-properties"), { loose: true }],
+                require.resolve("@babel/plugin-transform-arrow-functions"),
+                require.resolve("@babel/plugin-syntax-dynamic-import"),
+                require.resolve("@babel/plugin-syntax-import-meta"),
+                require.resolve("@babel/plugin-proposal-json-strings"),
                 require.resolve("@babel/plugin-proposal-function-sent"),
                 require.resolve("@babel/plugin-proposal-export-namespace-from"),
                 require.resolve("@babel/plugin-proposal-numeric-separator"),


### PR DESCRIPTION
== Description ==
when using @babel/plugin-proposal-class-properties & @babel/plugin-proposal-decorators in combination, load decorator plugin first, and the class properties in loose mode when decorator is loaded in legacy mode to follow the babel documentation https://babeljs.io/docs/en/babel-plugin-proposal-decorators

== Closes issue(s) ==

== Changes ==
webpacks babel plugin order and options

== Affected Packages ==
webpack-config