### PR TITLE
suppport browserslist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2159,6 +2159,90 @@
         "parse-json": "^4.0.0"
       }
     },
+    "cp-file": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cp-file/-/cp-file-7.0.0.tgz",
+      "integrity": "sha512-0Cbj7gyvFVApzpK/uhCtQ/9kE9UnYpxMzaq5nQQC/Dh4iaj5fxp7iEFIullrYwzj8nf0qnsI1Qsx34hAeAebvw==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^3.0.0",
+        "nested-error-stacks": "^2.0.0",
+        "p-event": "^4.1.0"
+      },
+      "dependencies": {
+        "make-dir": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        }
+      }
+    },
+    "cpy": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cpy/-/cpy-8.0.1.tgz",
+      "integrity": "sha512-XplonbFkGld3KST+wKFutU+Al3srtT9RaeLTJeRY47QzzLDlA5kpK4s+o0DdgRx7W0cdkifOehGnCBCGIFfdeg==",
+      "dev": true,
+      "requires": {
+        "arrify": "^2.0.1",
+        "cp-file": "^7.0.0",
+        "globby": "^9.2.0",
+        "has-glob": "^1.0.0",
+        "junk": "^3.1.0",
+        "nested-error-stacks": "^2.1.0",
+        "p-all": "^2.1.0"
+      },
+      "dependencies": {
+        "arrify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+          "dev": true
+        }
+      }
+    },
+    "cpy-cli": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cpy-cli/-/cpy-cli-3.1.0.tgz",
+      "integrity": "sha512-LJhHvFragWvIsJH1kjhzZwGSagukewJZ5nV5yjMc5TILs+Z/CbZSvX0W9t9XC26Mw32j56UHjR3co5kAXaeTwg==",
+      "dev": true,
+      "requires": {
+        "cpy": "^8.0.0",
+        "meow": "^5.0.0"
+      },
+      "dependencies": {
+        "meow": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
+          "integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
+          "dev": true,
+          "requires": {
+            "camelcase-keys": "^4.0.0",
+            "decamelize-keys": "^1.0.0",
+            "loud-rejection": "^1.0.0",
+            "minimist-options": "^3.0.1",
+            "normalize-package-data": "^2.3.4",
+            "read-pkg-up": "^3.0.0",
+            "redent": "^2.0.0",
+            "trim-newlines": "^2.0.0",
+            "yargs-parser": "^10.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -3731,6 +3815,26 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
+    "has-glob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-glob/-/has-glob-1.0.0.tgz",
+      "integrity": "sha1-mqqe7b/7G6OZCnsAEPtnjuAIEgc=",
+      "dev": true,
+      "requires": {
+        "is-glob": "^3.0.0"
+      },
+      "dependencies": {
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.0"
+          }
+        }
+      }
+    },
     "has-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
@@ -4369,6 +4473,12 @@
         "verror": "1.10.0"
       }
     },
+    "junk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/junk/-/junk-3.1.0.tgz",
+      "integrity": "sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==",
+      "dev": true
+    },
     "kind-of": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -4871,6 +4981,12 @@
       "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
     },
+    "nested-error-stacks": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
+      "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
+      "dev": true
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -5242,11 +5358,29 @@
         "os-tmpdir": "^1.0.0"
       }
     },
+    "p-all": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-all/-/p-all-2.1.0.tgz",
+      "integrity": "sha512-HbZxz5FONzz/z2gJfk6bFca0BCiSRF8jU3yCsWOen/vR6lZjfPOu/e7L3uFzTW1i0H8TlC3vqQstEJPQL4/uLA==",
+      "dev": true,
+      "requires": {
+        "p-map": "^2.0.0"
+      }
+    },
     "p-defer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
       "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
       "dev": true
+    },
+    "p-event": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.1.0.tgz",
+      "integrity": "sha512-4vAd06GCsgflX4wHN1JqrMzBh/8QZ4j+rzp0cd2scXRwuBEv+QR3wrVA5aLhWDLw4y2WgDKvzWF3CCLmVM1UgA==",
+      "dev": true,
+      "requires": {
+        "p-timeout": "^2.0.1"
+      }
     },
     "p-finally": {
       "version": "1.0.0",
@@ -5313,6 +5447,15 @@
       "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
       "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
       "dev": true
+    },
+    "p-timeout": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
+      "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+      "dev": true,
+      "requires": {
+        "p-finally": "^1.0.0"
+      }
     },
     "p-try": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@types/eslint": "^6.1.1",
     "babel-eslint": "^10.0.3",
+    "cpy-cli": "^3.1.0",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.1.0",
     "eslint-config-pv": "^2.2.2",

--- a/packages/pv-scripts/README.md
+++ b/packages/pv-scripts/README.md
@@ -106,6 +106,10 @@ Valid webpack.config file which will be merged with the module build of the prod
 **webpack.config.prod.legacy.js:**
 Valid webpack.config file which will be merged with the legacy build of the prod default config.
 
+#### Browserslist
+
+A default browser query is used for compiling javascript and css. i.e. IE11 for the "legacy" bundle and latest 2 versions of evergreen browsers (chrome, firefox, safari, edge) for the "modern" bundle. And all combined for the css output. You can define your own [browserslist](https://github.com/browserslist/browserslist) to override any of these target groups. Don't forget to define default browsers, browser for `[modern]` or `[legacy]` environment. See default [.browserslistrc](https://github.com/pro-vision/fe-tools/tree/master/packages/webpack-config/src/config/.browserslistrc) file for an example.
+
 ## Examples
 
 You can find example projects in the `examples` folder:

--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/pro-vision/fe-tools"
   },
   "scripts": {
-    "build": "rollup src/webpack/webpack.config.js --file lib/webpack-config.js --format cjs"
+    "build": "rollup src/webpack/webpack.config.js --file lib/webpack-config.js --format cjs && cpy src/config/.browserslistrc lib/"
   },
   "dependencies": {
     "@babel/core": "7.8.6",
@@ -43,6 +43,7 @@
     "@babel/preset-typescript": "7.8.3",
     "@babel/runtime": "7.8.4",
     "babel-loader": "8.0.6",
+    "browserslist": "4.9.1",
     "clean-webpack-plugin": "3.0.0",
     "copy-webpack-plugin": "5.1.1",
     "css-loader": "3.4.2",

--- a/packages/webpack-config/src/config/.browserslistrc
+++ b/packages/webpack-config/src/config/.browserslistrc
@@ -1,0 +1,24 @@
+# pv-scripts default target browsers,
+# will be overridden with project browserslist
+
+# default, (modern+legacy) used for PostCSS
+last 2 firefox versions
+last 2 chrome versions
+last 2 and_chr versions
+last 2 safari versions
+last 2 ios_saf versions
+last 2 edge versions
+IE >= 11
+
+# will be used for modern bundle
+[modern]
+last 2 firefox versions
+last 2 chrome versions
+last 2 and_chr versions
+last 2 safari versions
+last 2 ios_saf versions
+last 2 edge versions
+
+# will be used for legacy bundle
+[legacy]
+IE >= 11

--- a/packages/webpack-config/src/webpack/base/getBrowserslist.js
+++ b/packages/webpack-config/src/webpack/base/getBrowserslist.js
@@ -1,0 +1,19 @@
+import browserslist from "browserslist";
+
+const path = require("path");
+
+/**
+ * get browserslist from the project calling pv-scripts,
+ * fallback to default browsers list
+ *
+ * @export
+ * @returns {object}
+ */
+export default function getBrowserslist() {
+  const projectBrowsersList = browserslist.findConfig(path.resolve(".")) || {};
+
+  // default browserslist is copied to the same output directory during the build
+  const defaultBrowsersList = browserslist.findConfig(path.resolve(__dirname));
+
+  return Object.assign({}, defaultBrowsersList, projectBrowsersList);
+}

--- a/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileES/legacy.js
+++ b/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileES/legacy.js
@@ -1,3 +1,5 @@
+import getBrowserslist from "../../../getBrowserslist";
+
 const path = require("path");
 
 export const legacyCompileES = {
@@ -14,9 +16,7 @@ export const legacyCompileES = {
                 [
                   require.resolve("@babel/preset-env"),
                   {
-                    targets: {
-                      esmodules: false
-                    }
+                    targets: getBrowserslist().legacy
                   }
                 ]
               ],

--- a/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileES/module.js
+++ b/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileES/module.js
@@ -1,3 +1,5 @@
+import getBrowserslist from "../../../getBrowserslist";
+
 const path = require("path");
 
 export const moduleCompileES = {
@@ -14,9 +16,7 @@ export const moduleCompileES = {
                 [
                   require.resolve("@babel/preset-env"),
                   {
-                    targets: {
-                      esmodules: true
-                    }
+                    targets: getBrowserslist().modern,
                   }
                 ]
               ],

--- a/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileJSX/legacy.js
+++ b/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileJSX/legacy.js
@@ -1,3 +1,5 @@
+import getBrowserslist from "../../../getBrowserslist";
+
 export const legacyCompileJSX = {
   module: {
     rules: [
@@ -12,9 +14,7 @@ export const legacyCompileJSX = {
                 [
                   require.resolve("@babel/preset-env"),
                   {
-                    targets: {
-                      esmodules: false
-                    }
+                    targets: getBrowserslist().legacy
                   }
                 ],
                 require.resolve("@babel/preset-react")

--- a/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileJSX/module.js
+++ b/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileJSX/module.js
@@ -1,3 +1,5 @@
+import getBrowserslist from "../../../getBrowserslist";
+
 export const moduleCompileJSX = {
   module: {
     rules: [
@@ -12,9 +14,7 @@ export const moduleCompileJSX = {
                 [
                   require.resolve("@babel/preset-env"),
                   {
-                    targets: {
-                      esmodules: true
-                    }
+                    targets: getBrowserslist().modern
                   }
                 ],
                 require.resolve("@babel/preset-react")

--- a/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileTS/legacy.js
+++ b/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileTS/legacy.js
@@ -1,3 +1,5 @@
+import getBrowserslist from "../../../getBrowserslist";
+
 const path = require("path");
 
 export const legacyCompileTS = {
@@ -14,9 +16,7 @@ export const legacyCompileTS = {
                 [
                   require.resolve("@babel/preset-env"),
                   {
-                    targets: {
-                      esmodules: false
-                    }
+                    targets: getBrowserslist().legacy
                   }
                 ],
                 require.resolve("@babel/preset-typescript")

--- a/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileTS/module.js
+++ b/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileTS/module.js
@@ -1,3 +1,5 @@
+import getBrowserslist from "../../../getBrowserslist";
+
 const path = require("path");
 
 export const moduleCompileTS = {
@@ -14,9 +16,7 @@ export const moduleCompileTS = {
                 [
                   require.resolve("@babel/preset-env"),
                   {
-                    targets: {
-                      esmodules: true
-                    }
+                    targets: getBrowserslist().modern
                   }
                 ],
                 require.resolve("@babel/preset-typescript")

--- a/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileTSX/legacy.js
+++ b/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileTSX/legacy.js
@@ -1,3 +1,5 @@
+import getBrowserslist from "../../../getBrowserslist";
+
 export const legacyCompileTSX = {
   module: {
     rules: [
@@ -12,9 +14,7 @@ export const legacyCompileTSX = {
                 [
                   require.resolve("@babel/preset-env"),
                   {
-                    targets: {
-                      esmodules: false
-                    }
+                    targets: getBrowserslist().legacy
                   }
                 ],
                 require.resolve("@babel/preset-react"),

--- a/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileTSX/module.js
+++ b/packages/webpack-config/src/webpack/base/tasks/jsLoading/compileTSX/module.js
@@ -1,3 +1,5 @@
+import getBrowserslist from "../../../getBrowserslist";
+
 export const moduleCompileTSX = {
   module: {
     rules: [
@@ -12,9 +14,7 @@ export const moduleCompileTSX = {
                 [
                   require.resolve("@babel/preset-env"),
                   {
-                    targets: {
-                      esmodules: true
-                    }
+                    targets: getBrowserslist().modern
                   }
                 ],
                 require.resolve("@babel/preset-react"),


### PR DESCRIPTION
define browser query for babel's preset-env for modern and legacy bundles,
merge with potentail custom browserslist from user

== Description ==
Currently babel config for preset-env plugin uses browser query `esmodule: true` which resolves to the first version of chrome, ff, opera... that suported  `<script type="module">`. Which is 2-3 years old now. 
With this PR, babel-preset env reads it's target browsers from the browserslist files(s), `modern` and `legacy` environmnet. A default browserlist (modern: last 2 versions of Chrome, Chrome android, Firefox, Safari, Safari ios and Edge, legacy: ie11) is provided to be used in case projects using pv-script / pv-webpack-config don't have browserslist defined.

== Closes issue(s) ==


== Changes ==


== Affected Packages ==
webpack-config