### PR TITLE
pv-scripts flags to generate bundle analyzing stats

### DIFF
--- a/packages/pv-scripts/README.md
+++ b/packages/pv-scripts/README.md
@@ -33,6 +33,13 @@ Transpiles and bundles your code (JS/TS/JSX/TSX/SCSS) via `webpack` (+ all neede
 npx pv-scripts prod
 ```
 
+#### CLI flags
+
+##### `--stats` or `--statsJson`
+Webpack build will use [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer) to generate an html report or json output regarding the bundle sizes and its composition. Which will be stored under `target/report_module.html | target/report_legacy.html` and `target/report_module.json | target/report_legacy.json`.
+
+This flag should only be used in combination with `prod` build to have a realistic information from the optimized bundles.
+
 ### Configuration
 
 #### Basic Configuration

--- a/packages/pv-scripts/bin/pv-scripts.js
+++ b/packages/pv-scripts/bin/pv-scripts.js
@@ -7,6 +7,14 @@ const scriptIndex = args.findIndex(
   x => x === 'prod' || x === 'dev'
 );
 
+// check if stats flag is not used in dev mode.
+if (args.includes("dev") && (args.includes("--stats") || args.includes("--statsJson"))) {
+  console.warn("PV_SCRIPTS: '--stats' & '--statsJson' flags should only be used in combination with prod build. To provide correct values and don't slow the development unnecessarily.");
+}
+// flags used to generate webpack-bundle-analyzer reports
+if (args.includes("--stats")) process.env.PV_WEBPACK_STATS = "html";
+if (args.includes("--statsJson")) process.env.PV_WEBPACK_STATS = "json";
+
 const script = scriptIndex === -1 ? args[0] : args[scriptIndex];
 
 const nodeArgs = scriptIndex > 0 ? args.slice(0, scriptIndex) : [];

--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -67,6 +67,7 @@
     "slash": "3.0.0",
     "style-loader": "1.1.3",
     "webpack": "4.41.6",
+    "webpack-bundle-analyzer": "3.6.0",
     "webpack-merge": "4.2.2"
   }
 }

--- a/packages/webpack-config/src/webpack/prod/legacy.js
+++ b/packages/webpack-config/src/webpack/prod/legacy.js
@@ -1,4 +1,5 @@
 import merge from "webpack-merge";
+import webpackBundleAnalyzer from "webpack-bundle-analyzer";
 
 // Base Config
 import { defaultConfigLegacy } from "../base/legacy";
@@ -7,4 +8,20 @@ import { basicSettings } from "./settings/basicSettings";
 // Tasks
 import { compileCSS } from "./tasks/compileCSS";
 
-export const prodConfigLegacy = merge(defaultConfigLegacy, basicSettings, compileCSS);
+const additionalPlugins = {
+  plugins: [],
+};
+
+if (process.env.PV_WEBPACK_STATS) {
+  additionalPlugins.plugins.push(
+    new webpackBundleAnalyzer.BundleAnalyzerPlugin({
+      analyzerMode: process.env.PV_WEBPACK_STATS === "json" ? "disabled" : "static",
+      generateStatsFile: process.env.PV_WEBPACK_STATS === "json",
+      openAnalyzer: false,
+      reportFilename: "report_legacy.html",
+      statsFilename: "report_legacy.json",
+    })
+  );
+}
+
+export const prodConfigLegacy = merge(defaultConfigLegacy, basicSettings, compileCSS, additionalPlugins);

--- a/packages/webpack-config/src/webpack/prod/module.js
+++ b/packages/webpack-config/src/webpack/prod/module.js
@@ -1,4 +1,5 @@
 import merge from "webpack-merge";
+import webpackBundleAnalyzer from "webpack-bundle-analyzer";
 
 // Base Config
 import { defaultConfigModule } from "../base/module";
@@ -7,4 +8,20 @@ import { basicSettings } from "./settings/basicSettings";
 // Tasks
 import { compileCSS } from "./tasks/compileCSS";
 
-export const prodConfigModule = merge(defaultConfigModule, basicSettings, compileCSS);
+const additionalPlugins = {
+  plugins: [],
+};
+
+if (process.env.PV_WEBPACK_STATS) {
+  additionalPlugins.plugins.push(
+    new webpackBundleAnalyzer.BundleAnalyzerPlugin({
+      analyzerMode: process.env.PV_WEBPACK_STATS === "json" ? "disabled" : "static",
+      generateStatsFile: process.env.PV_WEBPACK_STATS === "json",
+      openAnalyzer: false,
+      reportFilename: "report_module.html",
+      statsFilename: "report_module.json",
+    })
+  );
+}
+
+export const prodConfigModule = merge(defaultConfigModule, basicSettings, compileCSS, additionalPlugins);


### PR DESCRIPTION
== Description ==
To allow users to have a better understanding of what is part of the output bundle and how much each module, lib, component adds to the bundle size, new cli flags will be introduced.
the `--stats` and `--statsJson` use webpack-bundle-analyzer to generate a html report with the visualization of the bundles (module and legacy). Or a json output which can also be used e.g. to feed webpack-visualizer with or used in some CI checks.

== Closes issue(s) ==


== Changes ==


== Affected Packages ==
pv-scripts
webpack-config