### PR TITLE
fix(webpack-config): fix missing browserslistrc file not beeing part of the published files

### DIFF
--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -9,7 +9,8 @@
     "lib": "lib"
   },
   "files": [
-    "lib/webpack-config.js"
+    "lib/webpack-config.js",
+    "lib/.browserslistrc"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION

== Description ==
default browserlist wasn't published, so if the user did not have any browserlist, the default browserslist browsers list was used and not the old browsers supporting module target. therefore the transpilation was for really low browser and this produced issue when code needed to be called as class for example

== Closes issue(s) ==


== Changes ==


== Affected Packages ==
webpack-config