### PR TITLE
feat(webpack-config): load 3rd party dependencies' source-map and integrate in output source-map

### DIFF
--- a/packages/webpack-config/package-lock.json
+++ b/packages/webpack-config/package-lock.json
@@ -9908,6 +9908,25 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
+    "source-map-loader": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.2.4.tgz",
+      "integrity": "sha512-OU6UJUty+i2JDpTItnizPrlpOIBLmQbWMuBg9q5bVtnHACqw1tn9nNwqJLbv0/00JjnJb/Ee5g5WS5vrRv7zIQ==",
+      "requires": {
+        "async": "^2.5.0",
+        "loader-utils": "^1.1.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        }
+      }
+    },
     "source-map-resolve": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",

--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -66,6 +66,7 @@
     "resolve": "1.15.1",
     "sass-loader": "8.0.2",
     "slash": "3.0.0",
+    "source-map-loader": "0.2.4",
     "style-loader": "1.1.3",
     "webpack": "4.41.6",
     "webpack-bundle-analyzer": "3.6.0",

--- a/packages/webpack-config/src/webpack/dev/module.js
+++ b/packages/webpack-config/src/webpack/dev/module.js
@@ -7,5 +7,6 @@ import { basicSettings } from "./settings/basicSettings";
 import { devServerSettings } from "./settings/devServerSettings";
 // Tasks
 import { moduleCompileCSS } from "./tasks/compileCSS/module";
+import { moduleLoadSourceMaps } from "./tasks/loadSourceMaps/module";
 
-export const devConfigModule = merge(defaultConfigModule, basicSettings, devServerSettings, moduleCompileCSS);
+export const devConfigModule = merge(defaultConfigModule, basicSettings, devServerSettings, moduleCompileCSS, moduleLoadSourceMaps);

--- a/packages/webpack-config/src/webpack/dev/tasks/loadSourceMaps/module.js
+++ b/packages/webpack-config/src/webpack/dev/tasks/loadSourceMaps/module.js
@@ -1,0 +1,14 @@
+/**
+ * add source-map of any third party dependency to the output source-map
+ */
+export const moduleLoadSourceMaps = {
+  module: {
+    rules: [{
+      // assuming third party dependencies such as @kluntje have only .js or .mjs extensions
+      test: /\.(js|mjs)$/,
+      use: [
+        "source-map-loader",
+      ]
+    }],
+  },
+};


### PR DESCRIPTION
to allow better readability during debugging, load source-maps which are not generated during the build (i.e. from 3rd party dependencies) as well.

== Description ==


== Closes issue(s) ==


== Changes ==


== Affected Packages ==
webpack-config