### PR TITLE
feat(webpack-config): add ".mjs" to webpack extentions to better support ootb esm modules

### DIFF
--- a/packages/webpack-config/src/webpack/base/settings/resolve.js
+++ b/packages/webpack-config/src/webpack/base/settings/resolve.js
@@ -5,7 +5,7 @@ import { appPath } from "../../../helpers/paths";
 export const resolveSettings = {
   resolve: {
     // Add `.ts` as a resolvable extension.
-    extensions: [".ts", ".js", ".jsx", ".tsx"],
+    extensions: [".ts", ".mjs", ".js", ".jsx", ".tsx"],
     alias: {
       SRC: resolve(appPath, "src/"),
       JS: resolve(appPath, "src/js/"),


### PR DESCRIPTION
== Description ==
Altough Webpack 5, when released, should provide some tree shaking for CommonJs files, Webpack currently provides some good ootb functionality to tree shake es modules (ESM) (https://webpack.js.org/guides/tree-shaking/), it is common to use the `.mjs` extention when a library generates ES modules, and to distinguish it from other outputs with other module types. Webpack also has `.mjs` in it's default resolve extentions (https://webpack.js.org/configuration/resolve/#resolveextensions).
This PR adds the ".mjs" extension with a higher priority to ".js" extention to webpack config, to unitilize this optiomization mechanism.

== Closes issue(s) ==


== Changes ==
`resolve.extensions` list

== Affected Packages ==
webpack-config