### PR TITLE
fix(pv-scripts): support windows seperators as well

### DIFF
--- a/packages/pv-scripts/webpack/base/tasks/compileKluntje.js
+++ b/packages/pv-scripts/webpack/base/tasks/compileKluntje.js
@@ -4,7 +4,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /@kluntje\//,
+        test: /@kluntje[\\/]/,
         use: {
           loader: require.resolve("babel-loader"),
           options: {


### PR DESCRIPTION
== Description ==
for determining if a file is a @kluntje file, add windows path seperator `\` to the test in addition to the unix path seperator `/`

== Closes issue(s) ==


== Changes ==


== Affected Packages ==
