### PR TITLE
fix(assemble-lite, pv-stylemark): use data in layout folder only when…

### DIFF
--- a/packages/assemble-lite/Assemble.js
+++ b/packages/assemble-lite/Assemble.js
@@ -3,7 +3,7 @@ const { readJson, readFile } = require("fs-extra");
 const pvHandlebars = require("handlebars").create();
 const { loadFront } = require("yaml-front-matter");
 const handlebarsHelpers = require("handlebars-helpers/lib/index");
-const { safeLoad } = require("js-yaml");
+const { load } = require("js-yaml");
 
 const Timer = require("./Timer");
 const Visitor = require("./Visitor");
@@ -559,7 +559,7 @@ module.exports = class Assemble {
           if (ext === ".json") {
             dataPool[filename] = await readJson(path);
           } else if (ext === ".yaml" || ext === ".yml") {
-            dataPool[filename] = safeLoad(await readFile(path, "utf-8"), {
+            dataPool[filename] = load(await readFile(path, "utf-8"), {
               filename,
             });
           }

--- a/packages/pv-stylemark/gulp-tasks/clickdummy_tasks/assembleClickdummyComponents.js
+++ b/packages/pv-stylemark/gulp-tasks/clickdummy_tasks/assembleClickdummyComponents.js
@@ -28,8 +28,6 @@ const assembleClickdummyComponents = () => {
   });
 };
 
-assembleClickdummyComponents();
-
 module.exports = {
   assembleClickdummyComponents,
 };

--- a/packages/pv-stylemark/gulp-tasks/clickdummy_tasks/assembleClickdummyPages.js
+++ b/packages/pv-stylemark/gulp-tasks/clickdummy_tasks/assembleClickdummyPages.js
@@ -26,8 +26,6 @@ const assembleClickdummyPages = () => {
   });
 };
 
-assembleClickdummyPages();
-
 module.exports = {
   assembleClickdummyPages,
 };

--- a/packages/pv-stylemark/gulp-tasks/lsg_tasks/assembleLSGComponents.js
+++ b/packages/pv-stylemark/gulp-tasks/lsg_tasks/assembleLSGComponents.js
@@ -25,8 +25,6 @@ const assembleLSGComponents = () => {
   });
 };
 
-assembleLSGComponents();
-
 module.exports = {
   assembleLSGComponents,
 };

--- a/packages/pv-stylemark/scripts/buildStylemarkLsg.js
+++ b/packages/pv-stylemark/scripts/buildStylemarkLsg.js
@@ -25,7 +25,7 @@ async function buildStylemarkLsg({
     shouldCopyStyleguideFiles &&
       new Promise((resolve) => copyClickdummyFiles(resolve)),
     shouldAssemble && assembleClickdummyComponents(),
-    shouldAssemble & assembleClickdummyPages(),
+    shouldAssemble && assembleClickdummyPages(),
     shouldAssemble && assembleLSGComponents(),
   ]);
 

--- a/packages/pv-stylemark/scripts/dev.js
+++ b/packages/pv-stylemark/scripts/dev.js
@@ -3,17 +3,17 @@ const gulp = require("gulp");
 // Assemble Clickdummy
 const {
   assembleClickdummyComponents,
-} = require("../gulp-tasks/assembleWrapper/assembleClickdummyComponents");
+} = require("../gulp-tasks/clickdummy_tasks/assembleClickdummyComponents");
 const {
   assembleClickdummyPages,
-} = require("../gulp-tasks/assembleWrapper/assembleClickdummyPages");
+} = require("../gulp-tasks/clickdummy_tasks/assembleClickdummyPages");
 const {
   copyClickdummyFiles,
 } = require("../gulp-tasks/clickdummy_tasks/copyClickdummyFiles");
 // Assemble Stylemark
 const {
   assembleLSGComponents,
-} = require("../gulp-tasks/assembleWrapper/assembleLSGComponents");
+} = require("../gulp-tasks/lsg_tasks/assembleLSGComponents");
 const {
   copyStyleguideFiles,
 } = require("../gulp-tasks/lsg_tasks/copyStyleguideFiles");

--- a/packages/pv-stylemark/scripts/prod.js
+++ b/packages/pv-stylemark/scripts/prod.js
@@ -3,17 +3,17 @@ const gulp = require("gulp");
 // Assemble Clickdummy
 const {
   assembleClickdummyComponents,
-} = require("../gulp-tasks/assembleWrapper/assembleClickdummyComponents");
+} = require("../gulp-tasks/clickdummy_tasks/assembleClickdummyComponents");
 const {
   assembleClickdummyPages,
-} = require("../gulp-tasks/assembleWrapper/assembleClickdummyPages");
+} = require("../gulp-tasks/clickdummy_tasks/assembleClickdummyPages");
 const {
   copyClickdummyFiles,
 } = require("../gulp-tasks/clickdummy_tasks/copyClickdummyFiles");
 // Assemble Stylemark
 const {
   assembleLSGComponents,
-} = require("../gulp-tasks/assembleWrapper/assembleLSGComponents");
+} = require("../gulp-tasks/lsg_tasks/assembleLSGComponents");
 const {
   copyStyleguideFiles,
 } = require("../gulp-tasks/lsg_tasks/copyStyleguideFiles");

--- a/packages/pv-stylemark/webpack-plugin/getFilesToWatch.js
+++ b/packages/pv-stylemark/webpack-plugin/getFilesToWatch.js
@@ -9,38 +9,56 @@ const {
   lsgIndex,
   lsgAssetsSrc,
   hbsHelperSrc,
+  lsgTemplatesSrc,
+  lsgConfigPath
 } = getAppConfig();
 
+// glob pattern for the files used in the living styleguide
+const fileGlobes = {
+  staticStylemarkFiles: {
+    index: lsgIndex,
+    config: lsgConfigPath,
+    // stylemark .md files
+    markDown: join(componentsSrc, "**/*.md"),
+    // static assets / resources
+    resources: join(lsgAssetsSrc, "**"),
+  },
+  assembleFiles: {
+    // add .json,.yaml/.yml Component data files
+    data: join(componentsSrc, "**/*.{json,yaml,yml}"),
+    // add .json,.yaml/.yml Layout data files
+    additionalComponentData: join(cdTemplatesSrc, "**/*.{json,yaml,yml}"),
+    // handlebars helpers
+    helpers: join(hbsHelperSrc, "*.js"),
+    // add .hbs Components files
+    components: join(componentsSrc, "**/*.hbs"),
+    // add .hbs Pages files
+    pages: join(cdPagesSrc, "**/*.hbs"),
+    // add .hbs Template/Layout files
+    layouts: join(cdTemplatesSrc, "**/*.hbs"),
+    // Living styleguide Layouts
+    lsgLayouts: join(lsgTemplatesSrc, "**/*.hbs"),
+  },
+};
+
 const getFilesToWatch = async () => {
-  const files = {
-    staticStylemarkFiles: [
-      lsgIndex,
-      // stylemark .md files
-      ...(await asyncGlob(join(componentsSrc, "**/*.md"))),
-      // static assets / resources
-      ...(await asyncGlob(join(lsgAssetsSrc, "**"))),
-    ],
+  // get paths for assemble and lsg in parallel
+  const lsgFilesPromise = Promise.all(
+    Object.values(fileGlobes.staticStylemarkFiles).map(asyncGlob)
+  );
+  const assembleFilesPromise = Promise.all(
+    Object.values(fileGlobes.assembleFiles).flat().map(asyncGlob)
+  );
+  const lsgFiles = (await lsgFilesPromise).flat();
+  const assembleFiles = (await assembleFilesPromise).flat();
 
-    assembleFiles: [
-      // add .json Components files
-      ...(await asyncGlob(join(componentsSrc, "**/*.json"))),
-      // add .yaml/.yml Component files
-      ...(await asyncGlob(join(componentsSrc, "**/*.yaml"))),
-      ...(await asyncGlob(join(componentsSrc, "**/*.yml"))),
-      // handlebars helpers
-      ...(await asyncGlob(join(hbsHelperSrc, "*.js"))),
-      // add .hbs Components files
-      ...(await asyncGlob(join(componentsSrc, "**/*.hbs"))),
-      // add .hbs Pages files
-      ...(await asyncGlob(join(cdPagesSrc, "**/*.hbs"))),
-      // add .hbs Template files
-      ...(await asyncGlob(join(cdTemplatesSrc, "**/*.hbs"))),
-    ],
+  return {
+    lsgFiles,
+    assembleFiles,
   };
-
-  return files;
 };
 
 module.exports = {
+  fileGlobes,
   getFilesToWatch,
 };

--- a/packages/pv-stylemark/webpack-plugin/getFilesToWatch.js
+++ b/packages/pv-stylemark/webpack-plugin/getFilesToWatch.js
@@ -10,7 +10,7 @@ const {
   lsgAssetsSrc,
   hbsHelperSrc,
   lsgTemplatesSrc,
-  lsgConfigPath
+  lsgConfigPath,
 } = getAppConfig();
 
 // glob pattern for the files used in the living styleguide

--- a/packages/pv-stylemark/webpack-plugin/index.js
+++ b/packages/pv-stylemark/webpack-plugin/index.js
@@ -77,6 +77,9 @@ class PvStylemarkPlugin {
               lsgComponentsTargetDirectory: resolveApp(
                 join(destPath, "/lsg_components")
               ),
+              onError(errorMessage) {
+                compilation.errors.push(errorMessage);
+              },
             },
             this.firstRun ? null : changedAssembleFiles
           );


### PR DESCRIPTION
… rendering the components

not pages nor component in lsg directory, re-enable assemble instance for the stylemark webpack
plugin, add watch and re-build when stylemark config file changes

== Description ==


== Closes issue(s) ==


== Changes ==


== Affected Packages ==
assemble-lite
pv-stylemark