### PR TITLE
feat(custom-elements-data-extractor): add new package for generating html custom data based on custom elments js classes

### DIFF
--- a/packages/custom-elements-data-extractor/README.md
+++ b/packages/custom-elements-data-extractor/README.md
@@ -1,0 +1,162 @@
+# Custom Element Data Extractor
+
+Tooling to extract data regarding the properties / attributes of custom elements. And generate custom data for [VSCode auto compilation](https://github.com/microsoft/vscode-html-languageservice/blob/main/docs/customData.md) for custom html tags.
+
+## Usage
+
+Install module as local or global dependency and call as npm script or in the command line with:
+
+```cmd
+pv-custom-data --components "src/components/**/*.ts" --iconsDir "resources/icons/" --outDir "data/"
+```
+
+```js
+// Custom element's js class in src/components/.../pva-e-icon.ts
+
+/**
+ * (lazy-loaded) icon element
+ */
+@tag("pva-e-icon")
+class Icon extends Component {
+
+  // svg file name without extension
+  @prop
+  iconId: string;
+
+  constructor() {
+    super({
+      props: {
+        ratio: { type: "number" }
+      }
+    });
+  }
+```
+
+```json
+// pv.config.json
+{
+  "devServerPort": "8023",
+  "namespace": "pva"
+}
+```
+
+```cmd
+:: /resources/icons/
+
+|- pva-icon-close.svg
+|- pva-icon-plus.svg
+```
+
+```json
+// generated custom-elements.html-data.json in "/data" folder.
+{
+  "version": 1.1,
+  "tags": [
+    {
+      "name": "pva-e-icon",
+      "description": "(lazy-loaded) icon element",
+      "attributes": [
+        {
+          "name": "icon-id",
+          "description": "svg file name without extension",
+          "valueSet": "pva-e-icon:icon-id"
+        },
+        {
+          "name": "ratio",
+          "description": "",
+        }
+      ],
+      "references": [
+        {
+          "name": "Living Styleguide",
+          "url": "http://localhost:8023/styleguide/index.html#icon"
+        }
+      ]
+    }
+  ],
+  "valueSets": [
+    {
+      "name": "pva-e-icon:icon-id",
+      "values": [
+        {
+          "name": "pva-icon-close"
+        },
+        {
+          "name": "pva-icon-plus"
+        }
+      ]
+    }
+  ]
+}
+```
+
+You have to reference the generated file in `.vscode/settings.json`;
+
+```json
+// .vscode/settings.json
+{
+  // ...
+  "html.customData": [
+    "./path/to/custom-elements.html-data.json"
+  ]
+}
+```
+
+## CLI options
+
+### `-c, --components <components>`
+
+Glob pattern to the directory containing the components. e.g. 'src/components/**/*.ts'.
+
+### `-i, --iconsDir <iconsDir>`
+
+(Optional) relative path to the directory containing svg icons. These icons will be provided as the options for the `icon-id` attribute. e.g. 'resources/icons'.
+
+### `-o, --outDir [outDir]`
+
+Relative path to the directory were the generated HTML customData will be written to.
+Use `-o` without a value to generate the .json file to the current working directory. Omit the `-o` flag and no json file will be written to disk.
+
+## Node API
+
+### Example
+
+```javascript
+const CustomElementDataExtractor = require("@pro-vision/custom-elements-data-extractor");
+
+// customize
+const Extractor = class extends CustomElementDataExtractor {
+  /** @overrides */
+  getValues({ attributeName, elementName, propData }) {
+    // define fixed options for the user-card's `type` attribute
+    if (elementName === "pva-user-card" && attributeName === "type") return [
+      {name: "Standard"},
+      {name: "PRO"},
+      {name: "PRO+", description: "will add additional badges"}
+    ];
+    return super.getValues({ attributeName, elementName, propData });
+  }
+
+  /** @overrides */
+  getReferences(elementName) {
+    // add link to some other domain instead of local LSG instance when hovering over custom elements tags in VSCode
+    return [{name: "Documentation", url: `www.my.docs.com/${elementName}`}]
+  }
+}
+
+const extractor = new Extractor({
+  components: path.resolve(process.cwd(), "/src/components/**/*.ts"),
+  // other options
+  // namespace: "pva",
+  // port: "8080",
+  // iconsDir: path.join(process.cwd(), "/icons/"),
+});
+
+await extractor.extractAllCustomElementsData();
+
+// you will have access to the data via:
+// extractor.customElementsData;
+
+// generate html custom data json file
+await extractor.writeHTMLCustomData(process.cwd());
+```

--- a/packages/custom-elements-data-extractor/bin/cli.js
+++ b/packages/custom-elements-data-extractor/bin/cli.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+"use strict";
+
+const path = require("path");
+const { Command } = require("commander");
+const CustomElementDataExtractor = require("../index.js");
+const pkg = require("../package.json");
+
+const program = new Command();
+program.version(pkg.json);
+
+program
+  .option(
+    "-i, --iconsDir <iconsDir>",
+    "(optional) relative path to the directory containing svg icons. These icons will be provided as the options for the `icon-id` attribute. e.g. 'resources/icons'"
+  )
+  .option(
+    "-o, --outDir [outDir]",
+    "relative path to the directory were the generated HTML customData will be written to"
+  )
+  .requiredOption(
+    "-c, --components <components>",
+    "glob pattern to the directory containing the components. e.g 'src/components/**/*.ts'"
+  )
+  ;
+
+program.parse(process.argv);
+const options = program.opts();
+
+async function run() {
+  // read port and namespace from projects pv.config.js if it exists
+  let pvConfig;
+  try {
+    pvConfig = require(path.resolve(process.cwd(), "pv.config.js"));
+  } catch (_err) {
+    // no pv.config.js
+  }
+
+  const extractor = new CustomElementDataExtractor({
+    port: pvConfig ? pvConfig.devServerPort : undefined,
+    namespace: pvConfig ? pvConfig.namespace : undefined,
+    components: path.join(process.cwd(), options.components),
+    iconsDir: options.iconsDir ? path.join(process.cwd(), options.iconsDir) : undefined,
+  });
+
+  await extractor.extractAllCustomElementsData();
+
+  if (options.outDir) {
+    const outDir = typeof options.outDir === "boolean" ? "." : options.outDir;
+    await extractor.writeHTMLCustomData(path.join(process.cwd(), outDir));
+  }
+
+  process.exit(0);
+}
+
+run();

--- a/packages/custom-elements-data-extractor/index.js
+++ b/packages/custom-elements-data-extractor/index.js
@@ -1,0 +1,381 @@
+const path = require("path");
+const fs = require("fs");
+const { promisify } = require("util");
+const globby = require("globby");
+const slash = require("slash");
+const parser = require("@babel/parser");
+const { default: traverse } = require("@babel/traverse");
+const doctrine = require("doctrine");
+const kebabCase = require("kebab-case");
+const { titleCase } = require("title-case");
+const mkdirp = require("mkdirp");
+
+const readFile = promisify(fs.readFile);
+const writeFile = promisify(fs.writeFile);
+
+/**
+ * @typedef {Object} CustomElementsData
+ * @property {boolean} descriptions - info regarding this Custom Element written as leading comment(s) to its class definition
+ * @property {PropData[]} props - list of its props
+ */
+
+/**
+ * @typedef {Object} PropData
+ * @property {string} name - property's name
+ * @property {string[]} descriptions - info regarding this property written as leading comment(s)
+ * @property {Array<{key: string, value:*}>} value - info regarding this property such as it being mandatory etc. {@see https://github.com/kluntje/kluntje/tree/develop/packages/core#props}
+ */
+
+/**
+ * {@see https://github.com/microsoft/vscode-html-languageservice/blob/a78978e573337f2766cfbe685c06de40d4d47a49/docs/customData.schema.json#L66}
+ * @typedef {Object} AttributeData
+ * @property {string} name - attribute's name
+ * @property {string} descriptions - info regarding this attribute
+ * @property {Array<{name:string}>} values - possible values which this attribute can have
+ */
+
+/**
+ * provide methods to extract property/attribute information from custom element classes
+ * and generates e.g vscode`s html.customData {@see https://github.com/microsoft/vscode-html-languageservice/blob/main/docs/customData.md}
+ *
+ * @class Extract
+ */
+class CustomElementDataExtractor {
+  /** @type {[key: string]: CustomElementsData} */
+  customElementsData = {};
+
+  /**
+   * list of plugins used by babel parser to parse the components javascript file
+   * @readonly
+   */
+  get babelParserPlugins() {
+    return ["typescript", "classProperties", "decorators-legacy"];
+  }
+
+  /**
+   * name of decorator without the "@" sign which generates a component property
+   * @readonly
+   */
+  get propDecoratorName() {
+    return "prop";
+  }
+
+  /**
+   * Creates an instance of Extract.
+   * @param {Object} arg
+   * @param {string|number} [arg.port] - port number for the local FE dev-server
+   * @param {string|number} arg.namespace - project prefix e.g. ("pva") {@see https://github.com/pro-vision/fe-tools/tree/master/packages/pv-scripts}
+   * @param {string} arg.components - glob pattern with absolute path to all custom elements classes which their data needs to be extracted
+   * @param {string} [arg.iconsDir] - absolute path to the root folder of avg icons
+   * @memberof Extract
+   */
+  constructor({ port, namespace, components, iconsDir }) {
+    this.port = port;
+    // "pva" -> "pva-"
+    this.namespace = namespace ? `${namespace}-` : "";
+    this.components = slash(components);
+
+    if (iconsDir) this.iconsDir = slash(path.join(iconsDir, "/"));
+  }
+
+  /**
+   * extract text content from the node's leading comments or comment blocks including JSDoc
+   *
+   * @param {Node} node - AST Node which might have a leading comment
+   * @returns {string[]}
+   */
+  getDescriptions(node) {
+    return (node.leadingComments || []).map((comment) => {
+      if (comment.type === "CommentBlock") {
+        const jsdocAst = doctrine.parse(comment.value, { unwrap: true });
+        return jsdocAst.description;
+      }
+      return comment.value.trim();
+    });
+  }
+
+  /**
+   * generates the custom elements tag name based on its file path
+   *
+   * @param {string} filePath - absolute path to the components file (with unix separators)
+   * @param {*} _code - content of the components file
+   * @returns {string}
+   */
+  getElementName(filePath, _code) {
+    return path.basename(filePath, ".ts");
+  }
+
+  /**
+   * return options which the given attribute for the element can have.
+   *
+   * @param {Object} param
+   * @param {string} param.attributeName - attribute name e.g `ajax-url`
+   * @param {string} param.elementName - custom elements tag name e.g. `pva-button`
+   * @param {PropData} param.propData - extracted data from the Custom elements JS class
+   * @returns {Array<{name:string}>|null}
+   *
+   * @example
+   * // <elem dir="ltr" />
+   * getValues({attributeName}) { if (attributeName="dir") return [{name: "rtl"}, {name: "ltr"}]}
+   */
+  getValues({ attributeName, elementName: _elementName, propData: _propData }) {
+    if (attributeName === "icon-id") {
+      return this.getIconsList().map((name) => ({
+        name,
+      }));
+    }
+
+    return null;
+  }
+
+  /**
+   * returns a list of references for the tag shown in completion and hover
+   * link to the living styleguide entry is returned by default
+   * @param {string} elementName - custom elements tag name
+   * @returns {Array<{name: string, url: string}>} - {@see https://github.com/microsoft/vscode-html-languageservice/blob/a78978e573337f2766cfbe685c06de40d4d47a49/docs/customData.schema.json#L10}
+   */
+  getReferences(elementName) {
+    return [
+      {
+        name: "Living Styleguide",
+        url: `http://localhost:${
+          this.port
+        }/styleguide/index.html#${elementName
+          .replace(this.namespace, "")
+          .replace(/^(e|m)-/, "")}`,
+      },
+    ];
+  }
+
+  /**
+   * returns the (kebab-case) name for the attribute for the given (camelCase) property
+   *
+   * @param {string} propName
+   * @returns {string}
+   */
+  getAttributeName(propName) {
+    return kebabCase(propName);
+  }
+
+  /**
+   * returns the custom html data info for the given property/attribute
+   *
+   * @param {PropData} prop - prop object
+   * @param {string} elementName - custom elements tag name
+   * @returns {AttributeData} - {@see https://github.com/microsoft/vscode-html-languageservice/blob/a78978e573337f2766cfbe685c06de40d4d47a49/docs/customData.schema.json#L66}
+   */
+  getAttributeData(prop, elementName) {
+    const attrName = this.getAttributeName(prop.name);
+    const attributeData = {
+      name: attrName,
+      description: prop.descriptions.join("\n").trim(),
+    };
+
+    const values = this.getValues({
+      attributeName: attrName,
+      propData: prop,
+      elementName,
+    });
+
+    if (Array.isArray(values) && values.length) attributeData.values = values;
+
+    return attributeData;
+  }
+
+  /**
+   * returns the list of icons "names" which are used for the icon elements attribute
+   *
+   * @returns {string[]}
+   */
+  getIconsList() {
+    if (!this.iconsDir) return [];
+
+    const iconPaths = globby.sync(this.iconsDir, {
+      expandDirectories: {
+        extensions: ["svg"],
+      },
+    });
+
+    return iconPaths.map((filePath) =>
+      filePath.replace(this.iconsDir, "").replace(/\.svg$/, "")
+    );
+  }
+
+  /**
+   * extracts props from props object in constructor or class fields with `@prop` decorator.
+   * For all component classes in glob pattern
+   * @async
+   */
+  async extractAllCustomElementsData() {
+    for await (const filePath of globby.stream(this.components)) {
+      const code = await readFile(filePath, { encoding: "utf-8" });
+      const elementName = this.getElementName(filePath, code);
+      const customElementsData = this.extractCustomElementsData(code);
+      if (customElementsData)
+        this.customElementsData[elementName] = customElementsData;
+    }
+  }
+
+  /**
+   * extracts props from props object in constructor or class fields with `@prop` decorator.
+   * @param {string} code - JS/TS code for the components custom element class
+   * @returns {CustomElementsData|undefined}
+   */
+  extractCustomElementsData(code) {
+    let result, ast;
+
+    try {
+      ast = parser.parse(code, {
+        sourceType: "module",
+        plugins: this.babelParserPlugins,
+      });
+    } catch (err) {
+      // parse error when code has some syntax issues
+      console.error(err);
+      return result;
+    }
+
+    traverse(ast, {
+      // extract comment from the custom element class
+      ClassDeclaration: (nodePath) => {
+        result = {
+          descriptions: this.getDescriptions(nodePath.node),
+          props: [],
+        };
+      },
+      // extract the data from `props` in the constructor argument.
+      ClassMethod: (nodePath) => {
+        if (nodePath.node.kind === "constructor") {
+          traverse(
+            nodePath.node,
+            {
+              enter: (subNodePath) => {
+                if (subNodePath.isIdentifier({ name: "props" })) {
+                  const propsData = subNodePath.container.value.properties.map(
+                    (property) => ({
+                      name: property.key.name,
+                      descriptions: this.getDescriptions(property),
+                      value: property.value.properties.map((propDef) => ({
+                        key: propDef.key.name,
+                        value: propDef.value.value,
+                      })),
+                    })
+                  );
+
+                  result.props.push(...propsData);
+                }
+              },
+            },
+            nodePath.scope,
+            nodePath.state,
+            nodePath
+          );
+        }
+      },
+
+      // via `@prop` decorators
+      ClassProperty: (nodePath) => {
+        if (nodePath.node.decorators) {
+          nodePath.node.decorators.forEach((n) => {
+            // `@prop foo`
+            if (
+              n.expression.type === "Identifier" &&
+              n.expression.name === this.propDecoratorName
+            ) {
+              result.props.push({
+                name: nodePath.node.key.name,
+                descriptions: this.getDescriptions(nodePath.node),
+                value: [],
+              });
+            }
+            // `@prop({required: true}) foo`
+            else if (
+              n.expression.type === "CallExpression" &&
+              n.expression.callee.name === this.propDecoratorName
+            ) {
+              const value = n.expression.arguments?.[0].properties.map((p) => ({
+                key: p.key.name,
+                value: p.value.value,
+              }));
+
+              result.props.push({
+                name: nodePath.node.key.name,
+                descriptions: this.getDescriptions(nodePath.node),
+                value,
+              });
+            }
+          });
+        }
+      },
+    });
+
+    return result;
+  }
+
+  /**
+   * generates object for vscode`s html.customData
+   * {@see https://github.com/microsoft/vscode-html-languageservice/blob/main/docs/customData.md}
+   *
+   * @returns {Object} - {@see https://github.com/microsoft/vscode-html-languageservice/blob/a78978e573337f2766cfbe685c06de40d4d47a49/docs/customData.schema.json}
+   */
+  getHTMLCustomData() {
+    const customElementsHtmlData = {
+      version: 1.1,
+      tags: [],
+      valueSets: [],
+    };
+    Object.entries(this.customElementsData).forEach(
+      ([elementName, customElementData]) => {
+        const tagData = {
+          // assuming file name and custom elements name are the same
+          name: elementName,
+          description:
+            customElementData.descriptions.join("\n").trim() ||
+            titleCase(
+              elementName
+                .replace(this.namespace, "")
+                .replace(/^(e|m)-/, "")
+                .replace(/-/g, " ")
+            ),
+          attributes: [],
+        };
+
+        const references = this.getReferences(elementName);
+        if (references) tagData.references = references;
+
+        customElementData.props.forEach((prop) => {
+          const attributeData = this.getAttributeData(prop, elementName);
+          if (attributeData.values) {
+            const valueSet = `${elementName}:${attributeData.name}`;
+            customElementsHtmlData.valueSets.push({
+              name: valueSet,
+              values: attributeData.values,
+            });
+
+            delete attributeData.values;
+            attributeData.valueSet = valueSet;
+          }
+
+          tagData.attributes.push(attributeData);
+        });
+
+        customElementsHtmlData.tags.push(tagData);
+      }
+    );
+
+    return customElementsHtmlData;
+  }
+
+  // html custom data is generated and written to disc
+  async writeHTMLCustomData(outputDir) {
+    const htmlCustomData = this.getHTMLCustomData();
+    // make sure folder exists
+    await mkdirp(outputDir);
+    await writeFile(
+      path.join(outputDir, "custom-elements.html-data.json"),
+      JSON.stringify(htmlCustomData, null, "  ")
+    );
+  }
+}
+
+module.exports = CustomElementDataExtractor;

--- a/packages/custom-elements-data-extractor/package-lock.json
+++ b/packages/custom-elements-data-extractor/package-lock.json
@@ -1,0 +1,412 @@
+{
+  "name": "@pro-vision/custom-elements-data-extractor",
+  "version": "0.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+      "requires": {
+        "@babel/highlight": "^7.12.13"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.13.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
+      "integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
+      "requires": {
+        "@babel/types": "^7.13.0",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+      "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.12.13",
+        "@babel/template": "^7.12.13",
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+      "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+      "requires": {
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+      "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+      "requires": {
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+    },
+    "@babel/highlight": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+      "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.12.11",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
+      "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw=="
+    },
+    "@babel/template": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+      "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+      "requires": {
+        "@babel/code-frame": "^7.12.13",
+        "@babel/parser": "^7.12.13",
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
+      "integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
+      "requires": {
+        "@babel/code-frame": "^7.12.13",
+        "@babel/generator": "^7.13.9",
+        "@babel/helper-function-name": "^7.12.13",
+        "@babel/helper-split-export-declaration": "^7.12.13",
+        "@babel/parser": "^7.13.13",
+        "@babel/types": "^7.13.13",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      }
+    },
+    "@babel/types": {
+      "version": "7.13.14",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+      "integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.12.11",
+        "lodash": "^4.17.19",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
+      "integrity": "sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==",
+      "requires": {
+        "@nodelib/fs.stat": "2.0.4",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+      "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q=="
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
+      "integrity": "sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==",
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.4",
+        "fastq": "^1.6.0"
+      }
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
+    },
+    "debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "requires": {
+        "path-type": "^4.0.0"
+      }
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+    },
+    "fast-glob": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+      "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.0",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.2",
+        "picomatch": "^2.2.1"
+      }
+    },
+    "fastq": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
+      "integrity": "sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==",
+      "requires": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+    },
+    "globby": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
+      "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
+      "requires": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.1.1",
+        "ignore": "^5.1.4",
+        "merge2": "^1.3.0",
+        "slash": "^3.0.0"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "ignore": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+    },
+    "kebab-case": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/kebab-case/-/kebab-case-1.0.1.tgz",
+      "integrity": "sha512-txPHx6nVLhv8PHGXIlAk0nYoh894SpAqGPXNvbg2hh8spvHXIah3+vT87DLoa59nKgC6scD3u3xAuRIgiMqbfQ=="
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
+    },
+    "micromatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+      "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+      "requires": {
+        "braces": "^3.0.1",
+        "picomatch": "^2.0.5"
+      }
+    },
+    "mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
+    },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+    },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "title-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/title-case/-/title-case-3.0.3.tgz",
+      "integrity": "sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==",
+      "requires": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "tslib": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+    }
+  }
+}

--- a/packages/custom-elements-data-extractor/package.json
+++ b/packages/custom-elements-data-extractor/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@pro-vision/custom-elements-data-extractor",
+  "version": "0.1.0",
+  "description": "Tooling to extract attributes data used in custom elements and generate HTML custom data to be used by vscode",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pro-vision/fe-tools.git",
+    "directory": "packages/custom-elements-data-extractor"
+  },
+  "scripts": {},
+  "keywords": [],
+  "author": "Mehran Behzad",
+  "license": "Apache-2.0",
+  "bin": {
+    "pv-custom-data": "./bin/cli.js"
+  },
+  "dependencies": {
+    "@babel/parser": "7.13.13",
+    "@babel/traverse": "7.13.13",
+    "commander": "7.2.0",
+    "doctrine": "3.0.0",
+    "globby": "11.0.3",
+    "kebab-case": "1.0.1",
+    "mkdirp": "1.0.4",
+    "slash": "3.0.0",
+    "title-case": "3.0.3"
+  }
+}


### PR DESCRIPTION


== Description ==

Node module and CLI to extract props/attribute data from `props` in constructor or `@prop` decorator in kluntje (or similar) components. And generates json file which can be used by vscode for auto suggestion for custom html tags.

== Closes issue(s) ==


== Changes ==


== Affected Packages ==
custom-elements-data-extractor (new)