### PR TITLE
fix(pv-scripts): ignore warning on missing source map in dependencies

### DIFF
--- a/packages/pv-scripts/webpack/base/legacy.js
+++ b/packages/pv-scripts/webpack/base/legacy.js
@@ -3,6 +3,7 @@ const { merge } = require("webpack-merge");
 // Settings
 const legacyEntrySettings = require("./settings/entry/legacy");
 const legacyOutputSettings = require("./settings/output/legacy");
+const baseSettings = require("./settings/baseSettings");
 const contextSettings = require("./settings/context");
 const resolveSettings = require("./settings/resolve");
 const performanceSettings = require("./settings/performance");
@@ -18,6 +19,7 @@ const compileCSS = require("./tasks/compileCSS");
 module.exports = merge(
   legacyEntrySettings,
   legacyOutputSettings,
+  baseSettings,
   contextSettings,
   resolveSettings,
   performanceSettings,

--- a/packages/pv-scripts/webpack/base/module.js
+++ b/packages/pv-scripts/webpack/base/module.js
@@ -3,6 +3,7 @@ const { merge } = require("webpack-merge");
 // Settings
 const moduleEntrySettings = require("./settings/entry/module");
 const moduleOutputSettings = require("./settings/output/module");
+const baseSettings = require("./settings/baseSettings");
 const contextSettings = require("./settings/context");
 const resolveSettings = require("./settings/resolve");
 const performanceSettings = require("./settings/performance");
@@ -29,6 +30,7 @@ const { useTS, copyStaticFiles, cleanDest, enableTypeCheck } = getBuildConfig();
 module.exports = merge(
   moduleEntrySettings,
   moduleOutputSettings,
+  baseSettings,
   contextSettings,
   resolveSettings,
   performanceSettings,

--- a/packages/pv-scripts/webpack/base/settings/baseSettings.js
+++ b/packages/pv-scripts/webpack/base/settings/baseSettings.js
@@ -1,0 +1,3 @@
+module.exports = {
+  ignoreWarnings: [/Failed to parse source map/],
+};


### PR DESCRIPTION
== Description ==


== Closes issue(s) ==


== Changes ==


== Affected Packages ==
