### PR TITLE
fix(pv-stylemark): use glob pattern to target files instead of directory to work around windows bug

### DIFF
--- a/packages/pv-stylemark/gulp-tasks/lsg_tasks/copyStyleguideFiles.js
+++ b/packages/pv-stylemark/gulp-tasks/lsg_tasks/copyStyleguideFiles.js
@@ -11,7 +11,9 @@ const copyMdFiles = () => {
 };
 
 const copyAssets = () => {
-  return src(join(lsgAssetsSrc, "**")).pipe(dest(join(destPath, "lsg_assets")));
+  return src(join(lsgAssetsSrc, "**/*.*")).pipe(
+    dest(join(destPath, "lsg_assets"))
+  );
 };
 
 const copyStyleguideFiles = (done) => {


### PR DESCRIPTION


this prevents the `error: [Error: EPERM: operation not permitted, futime] { errno: -4048, code:
'EPERM', syscall: 'futime'} ` error

== Description ==
The above error was thrown when the lsg's copyAsstes task tried to copy the directory while the files were watched for changes. coping files individually seems to work around this issue.

== Closes issue(s) ==


== Changes ==


== Affected Packages ==

pv-stylemark