### PR TITLE
fix(pv-scripts): fix the relative path to the default browserslistrc file

### DIFF
--- a/packages/pv-scripts/webpack/base/getBrowserslist.js
+++ b/packages/pv-scripts/webpack/base/getBrowserslist.js
@@ -11,8 +11,9 @@ const browserslist = require("browserslist");
 module.exports = function getBrowserslist() {
   const projectBrowsersList = browserslist.findConfig(path.resolve(".")) || {};
 
-  // default browserslist is copied to the same output directory during the build
-  const defaultBrowsersList = browserslist.findConfig(path.resolve(__dirname));
+  const defaultBrowsersList = browserslist.findConfig(
+    path.resolve(__dirname, "../../config")
+  );
 
   return Object.assign({}, defaultBrowsersList, projectBrowsersList);
 };


### PR DESCRIPTION


the path was broken during the project refactoring when all webpack config files were moved to
pv-scripts package

== Description ==
see above

== Closes issue(s) ==
-

== Changes ==


== Affected Packages ==
pv-scripts