### PR TITLE
feat(vscode-pv-handlebars-language-server): add autocompl. etc support to page and layout templates

### DIFF
--- a/packages/vscode-pv-handlebars-language-server/README.md
+++ b/packages/vscode-pv-handlebars-language-server/README.md
@@ -9,7 +9,7 @@ This Language Server provides
 
 ## Example
 
-![Example](https://github.com/pro-vision/fe-tools/tree/master/packages/vscode-pv-handlebars-language-server/images/example.gif)
+![Example](https://github.com/pro-vision/fe-tools/raw/master/packages/vscode-pv-handlebars-language-server/images/example.gif)
 
 ## Requirement
 

--- a/packages/vscode-pv-handlebars-language-server/client/tsconfig.json
+++ b/packages/vscode-pv-handlebars-language-server/client/tsconfig.json
@@ -1,13 +1,13 @@
 {
-	"compilerOptions": {
-		"target": "es2019",
-		"lib": ["ES2019"],
-		"module": "commonjs",
-		"moduleResolution": "node",
-		"outDir": "out",
-		"rootDir": "src",
-		"sourceMap": true
-	},
-	"include": ["src"],
-	"exclude": ["node_modules", ".vscode-test"]
+  "compilerOptions": {
+    "target": "es2019",
+    "lib": ["ES2019"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "outDir": "out",
+    "rootDir": "src",
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", ".vscode-test"]
 }

--- a/packages/vscode-pv-handlebars-language-server/package.json
+++ b/packages/vscode-pv-handlebars-language-server/package.json
@@ -1,71 +1,71 @@
 {
-	"name": "vscode-pv-handlebars-language-server",
-	"displayName": "p!v Handlebars Language Server",
-	"description": "A Language Server for Handlebars in Assemble(-lite) Projects",
-	"private": true,
-	"author": "Mehran Behzad",
-	"icon": "images/logo.png",
-	"license": "Apache-2.0",
-	"version": "0.7.5",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/pro-vision/fe-tools.git",
-		"directory": "packages/vscode-pv-handlebars-language-server"
-	},
-	"publishConfig": {
-		"access": "public"
-	},
-	"publisher": "pro-vision",
-	"keywords": [
-		"handlebars",
-		"vscode",
-		"language-server"
-	],
-	"engines": {
-		"vscode": "^1.43.0"
-	},
-	"activationEvents": [
-		"onLanguage:handlebars"
-	],
-	"main": "./client/out/extension",
-	"contributes": {
-		"configuration": {
-			"type": "object",
-			"title": "p!v Handlebars Language Server Configuration",
-			"properties": {
-				"P!VHandlebarsLanguageServer.showHoverInfo": {
-					"scope": "window",
-					"type": "boolean",
-					"default": true,
-					"description": "Shows links to documentation of handlebars helpers on hover."
-				},
-				"P!VHandlebarsLanguageServer.provideCssClassGoToDefinition": {
-					"scope": "window",
-					"type": "boolean",
-					"default": true,
-					"description": "Provides goto definition for css classes to their positions in .scss files."
-				},
-				"P!VHandlebarsLanguageServer.provideCssClassCompletion": {
-					"scope": "window",
-					"type": "boolean",
-					"default": true,
-					"description": "Provides completion for css classes in hbs files based on scss files."
-				}
-			}
-		}
-	},
-	"scripts": {
-		"vscode:prepublish": "npm run compile",
-		"compile": "tsc -b",
-		"watch": "tsc -b -w",
-		"postinstall": "cd client && npm install && cd ../server && npm install && cd ..",
-		"pkg": "vsce package --out \"releases\"",
-		"version": "npm run pkg && git add -A releases",
-		"deploy": "vsce publish"
-	},
-	"devDependencies": {
-		"@types/node": "^12.12.0",
-		"typescript": "^4.2.3",
-		"vsce": "^1.87.0"
-	}
+  "name": "vscode-pv-handlebars-language-server",
+  "displayName": "p!v Handlebars Language Server",
+  "description": "A Language Server for Handlebars in Assemble(-lite) Projects",
+  "private": true,
+  "author": "Mehran Behzad",
+  "icon": "images/logo.png",
+  "license": "Apache-2.0",
+  "version": "0.7.5",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pro-vision/fe-tools.git",
+    "directory": "packages/vscode-pv-handlebars-language-server"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "publisher": "pro-vision",
+  "keywords": [
+    "handlebars",
+    "vscode",
+    "language-server"
+  ],
+  "engines": {
+    "vscode": "^1.43.0"
+  },
+  "activationEvents": [
+    "onLanguage:handlebars"
+  ],
+  "main": "./client/out/extension",
+  "contributes": {
+    "configuration": {
+      "type": "object",
+      "title": "p!v Handlebars Language Server Configuration",
+      "properties": {
+        "P!VHandlebarsLanguageServer.showHoverInfo": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "description": "Shows links to documentation of handlebars helpers on hover."
+        },
+        "P!VHandlebarsLanguageServer.provideCssClassGoToDefinition": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "description": "Provides goto definition for css classes to their positions in .scss files."
+        },
+        "P!VHandlebarsLanguageServer.provideCssClassCompletion": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "description": "Provides completion for css classes in hbs files based on scss files."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -b",
+    "watch": "tsc -b -w",
+    "postinstall": "cd client && npm install && cd ../server && npm install && cd ..",
+    "pkg": "vsce package --out \"releases\"",
+    "version": "npm run pkg && git add -A releases",
+    "deploy": "vsce publish"
+  },
+  "devDependencies": {
+    "@types/node": "^12.12.0",
+    "typescript": "^4.2.3",
+    "vsce": "^1.87.0"
+  }
 }

--- a/packages/vscode-pv-handlebars-language-server/package.json
+++ b/packages/vscode-pv-handlebars-language-server/package.json
@@ -2,6 +2,7 @@
 	"name": "vscode-pv-handlebars-language-server",
 	"displayName": "p!v Handlebars Language Server",
 	"description": "A Language Server for Handlebars in Assemble(-lite) Projects",
+	"private": true,
 	"author": "Mehran Behzad",
 	"icon": "images/logo.png",
 	"license": "Apache-2.0",

--- a/packages/vscode-pv-handlebars-language-server/server/src/completionProvider.ts
+++ b/packages/vscode-pv-handlebars-language-server/server/src/completionProvider.ts
@@ -16,6 +16,7 @@ import {
   basename,
   getPVConfig,
   getFrontendRootPath,
+  getLayoutFiles,
 } from "./helpers";
 import { getClassRules } from "./cssProvider";
 import SettingsService from "./SettingsService";
@@ -189,6 +190,27 @@ export async function completionProvider(
           // then the project classes
           // then the author and 3rd party plugins'
           sortText: `${className.startsWith(basename(filePath)) ? "00" : ""}${className.startsWith(namespace) ? "11" : ""}${className}`,
+        }));
+  }
+
+  /*
+   layout reference in the yaml front matter:
+   
+   ---
+   ...
+   layout: name
+   ---
+  */
+  if (/^\n*---[^---]*layout:\s*(\w|\d)*$/.test(text)) {
+    const isPageTemplate = filePath.includes("/frontend/src/pages");
+    const layouts = await getLayoutFiles(componentsRootPath);
+    const relevantLayouts = layouts?.[isPageTemplate ? "pages" : "lsg"];
+    
+    if (relevantLayouts)
+      return Object.keys(relevantLayouts)
+        .map(layoutName => ({
+          label: layoutName,
+          kind: CompletionItemKind.Value,
         }));
   }
 

--- a/packages/vscode-pv-handlebars-language-server/server/src/completionProvider.ts
+++ b/packages/vscode-pv-handlebars-language-server/server/src/completionProvider.ts
@@ -195,7 +195,7 @@ export async function completionProvider(
 
   /*
    layout reference in the yaml front matter:
-   
+
    ---
    ...
    layout: name
@@ -205,7 +205,7 @@ export async function completionProvider(
     const isPageTemplate = filePath.includes("/frontend/src/pages");
     const layouts = await getLayoutFiles(componentsRootPath);
     const relevantLayouts = layouts?.[isPageTemplate ? "pages" : "lsg"];
-    
+
     if (relevantLayouts)
       return Object.keys(relevantLayouts)
         .map(layoutName => ({

--- a/packages/vscode-pv-handlebars-language-server/server/src/definitionProvider.ts
+++ b/packages/vscode-pv-handlebars-language-server/server/src/definitionProvider.ts
@@ -132,7 +132,7 @@ export async function definitionProvider(
     if (settings.provideCssClassGoToDefinition) return getCssClassDeclarationLocation(symbolName, filePath);
   }
   // <custom-element
-  else if (/<\/?[a-z]+[a-z0-9_-]+$/.test(textBefore)) {
+  else if (/<\/?[a-z]+[a-z0-9_-]+$/.test(textBefore) || / is="[a-z]+[a-z0-9_-]+$/.test(textBefore)) {
     const customElementFile = await globby(`${componentsRootPath}/**/${symbolName}.ts`);
     if (customElementFile.length) {
       const cePath = customElementFile[0];

--- a/packages/vscode-pv-handlebars-language-server/server/src/definitionProvider.ts
+++ b/packages/vscode-pv-handlebars-language-server/server/src/definitionProvider.ts
@@ -60,7 +60,7 @@ export async function definitionProvider(
     : filePath.includes("src/pages/")
       ? `${filePath.split("/frontend/src/pages")[0]}/frontend/src/components`
       : `${filePath.split("/frontend/src/layouts")[0]}/frontend/src/components`;
-  
+
   // e.g. {{> partial
   if (isPartial(textBefore)) {
     const partialPaths = await globby(`${componentsRootPath}/**/${symbolName}.hbs`);
@@ -141,7 +141,7 @@ export async function definitionProvider(
   }
   /*
    layout reference in the yaml front matter:
-   
+
    ---
    ...
    layout: name
@@ -162,14 +162,14 @@ export async function definitionProvider(
       // where placeholder is placed (if found)
       if (placeholderStart !== -1) {
         const before = fileContent.slice(0, placeholderStart);
-        const lineNumber = (before.match(/\n/g) || []).length;        
+        const lineNumber = (before.match(/\n/g) || []).length;
         return Location.create(URI.file(layoutFilePath).toString(), Range.create(lineNumber, 0, lineNumber, 1000));
       }
       // whole file
       else {
         return Location.create(URI.file(layoutFilePath).toString(), Range.create(0, 0, 0, 0));
       }
-      
+
     }
   }
   return null;

--- a/packages/vscode-pv-handlebars-language-server/server/src/definitionProvider.ts
+++ b/packages/vscode-pv-handlebars-language-server/server/src/definitionProvider.ts
@@ -54,7 +54,11 @@ export async function definitionProvider(
 
   const symbolName = getCurrentSymbolsName(document, position);
 
-  const componentsRootPath = `${filePath.split("/frontend/src/components")[0]}/frontend/src/components`;
+  const componentsRootPath = filePath.includes("src/components/")
+    ? `${filePath.split("/frontend/src/components")[0]}/frontend/src/components`
+    : filePath.includes("src/pages/")
+      ? `${filePath.split("/frontend/src/pages")[0]}/frontend/src/components`
+      : `${filePath.split("/frontend/src/layouts")[0]}/frontend/src/components`;
   // e.g. {{> partial
   if (isPartial(textBefore)) {
     const partialPaths = await globby(`${componentsRootPath}/**/${symbolName}.hbs`);

--- a/packages/vscode-pv-handlebars-language-server/server/src/helpers.ts
+++ b/packages/vscode-pv-handlebars-language-server/server/src/helpers.ts
@@ -59,7 +59,9 @@ export function getFilePath(document: TextDocument): string {
  * @returns {boolean}
  */
 export function isPVArchetype(templatePath: string): boolean {
-  return templatePath.includes("/frontend/src/components") || templatePath.includes("/frontend/src/pages");
+  return templatePath.includes("/frontend/src/components")
+   || templatePath.includes("/frontend/src/pages")
+   || templatePath.includes("/frontend/src/layouts");
 }
 
 /**

--- a/packages/vscode-pv-handlebars-language-server/server/src/helpers.ts
+++ b/packages/vscode-pv-handlebars-language-server/server/src/helpers.ts
@@ -155,9 +155,9 @@ interface LayoutFiles {lsg?: {[name: string]: string}, pages?: {[name: string]: 
 export async function getLayoutFiles(componentsRootPath: string): Promise<LayoutFiles | null> {
   const frontendRootPath = getFrontendRootPath(componentsRootPath);
   const pvConfig = getPVConfig(frontendRootPath);
-  
+
   if (pvConfig === null) return null;
-  
+
   const layouts: Array<{name: "lsg" | "pages", dir: string | undefined}> = [
     {
       name: "lsg",
@@ -168,7 +168,7 @@ export async function getLayoutFiles(componentsRootPath: string): Promise<Layout
       dir: pvConfig.cdTemplatesSrc,
     },
   ];
-  
+
   const layoutFiles: LayoutFiles = {};
 
   for (const {name, dir} of layouts) {

--- a/packages/vscode-pv-handlebars-language-server/server/src/helpers.ts
+++ b/packages/vscode-pv-handlebars-language-server/server/src/helpers.ts
@@ -10,6 +10,8 @@ import type { TextDocument } from "vscode-languageserver-textdocument";
 interface PVConfig {
   hbsHelperSrc?: string;
   namespace?: string;
+  lsgTemplatesSrc?: string;
+  cdTemplatesSrc?: string;
 }
 
 /**
@@ -145,6 +147,39 @@ export async function getCustomHelperFiles(componentsRootPath: string): Promise<
   const helpersGlob = toUnixPath(path.join(frontendRootPath, pvConfig.hbsHelperSrc, "/**/*.js"));
   const helperPaths = await globby(helpersGlob);
   return helperPaths.map(filePath => ({ path: filePath, name: path.basename(filePath, ".js") }));
+}
+
+interface LayoutFiles {lsg?: {[name: string]: string}, pages?: {[name: string]: string}}
+
+// list of hbs files which are used in assemble-lite as layouts for lsg components or pages
+export async function getLayoutFiles(componentsRootPath: string): Promise<LayoutFiles | null> {
+  const frontendRootPath = getFrontendRootPath(componentsRootPath);
+  const pvConfig = getPVConfig(frontendRootPath);
+  
+  if (pvConfig === null) return null;
+  
+  const layouts: Array<{name: "lsg" | "pages", dir: string | undefined}> = [
+    {
+      name: "lsg",
+      dir: pvConfig.lsgTemplatesSrc,
+    },
+    {
+      name: "pages",
+      dir: pvConfig.cdTemplatesSrc,
+    },
+  ];
+  
+  const layoutFiles: LayoutFiles = {};
+
+  for (const {name, dir} of layouts) {
+    if (dir) {
+      const pageLayoutsGlob = toUnixPath(path.join(frontendRootPath , dir, "/**/*.hbs"));
+      const layouts = await globby(pageLayoutsGlob);
+      layoutFiles[name] = Object.fromEntries(layouts.map(filePath => [path.basename(filePath, ".hbs"), filePath]));
+    }
+  }
+
+  return layoutFiles;
 }
 
 /**

--- a/packages/vscode-pv-handlebars-language-server/server/tsconfig.json
+++ b/packages/vscode-pv-handlebars-language-server/server/tsconfig.json
@@ -1,14 +1,14 @@
 {
-	"compilerOptions": {
-		"target": "es2019",
-		"lib": ["ES2019"],
-		"module": "commonjs",
-		"moduleResolution": "node",
-		"sourceMap": true,
-		"strict": true,
-		"outDir": "out",
-		"rootDir": "src"
-	},
-	"include": ["src"],
-	"exclude": ["node_modules", ".vscode-test"]
+  "compilerOptions": {
+    "target": "es2019",
+    "lib": ["ES2019"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "strict": true,
+    "outDir": "out",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", ".vscode-test"]
 }


### PR DESCRIPTION

== Description ==


== Closes issue(s) ==


== Changes ==


== Affected Packages ==
vscode-pv-handlebars-language-server