### PR TITLE
perf(pv-scripts): rethrow error thrown during devserver start

### DIFF
--- a/packages/pv-scripts/scripts/dev.js
+++ b/packages/pv-scripts/scripts/dev.js
@@ -42,7 +42,11 @@ prepareWebpackConfig("development").then((webpackConfig) => {
   }:${devServerConfig.port}`;
 
   // Launch WebpackDevServer.
-  devServer.startCallback(() => {
+  devServer.startCallback((error) => {
+    if (error) {
+      throw error;
+    }
+
     if (isInteractive) {
       clearConsole();
     }


### PR DESCRIPTION
== Description ==
I had an issue where some other dependencies had a dependency to webpack in a different version than pv-scripts', and npm installed the other webpack version as the main package and the pv-scripts' one only in pv-scripts node_module, during dev start both versions were somehow loaded and resulted to "The 'compilation' argument must be an instance of Compilation" error. It wasn't clear that an error was throw due to only "Starting the development server:." message being printed to the console.

== Closes issue(s) ==


== Changes ==


== Affected Packages ==
pv-scripts