### PR TITLE
fix(assemble-lite): fix order of data loads being dependent on the file read race condition

### DIFF
--- a/packages/assemble-lite/helper/io-helper.js
+++ b/packages/assemble-lite/helper/io-helper.js
@@ -30,17 +30,11 @@ const getPaths = async (globPattern) => {
     curPatterns = [globPattern];
   }
 
-  let paths = [];
-
-  await Promise.all(
-    curPatterns.map(async (pattern) => {
-      const curPaths = await asyncGlob(pattern);
-      paths = paths.concat(curPaths);
-      return curPaths;
-    })
+  const paths = await Promise.all(
+    curPatterns.map((pattern) => asyncGlob(pattern))
   );
 
-  return paths;
+  return paths.flat();
 };
 
 const asyncReadFile = (filePath) => {


### PR DESCRIPTION


make sure paths are retuned in the same order as the glob patterns passed to the function, to meke sure data files with the same name will overwrite each other each time in the same order and not depending on which was read faster from file system

== Description ==


== Closes issue(s) ==


== Changes ==


== Affected Packages ==
assemble-lite