### PR TITLE
feat(pv-scripts): use custom name for the global function to load webpack chunck

### DIFF
--- a/packages/pv-scripts/webpack/base/settings/output/legacy.js
+++ b/packages/pv-scripts/webpack/base/settings/output/legacy.js
@@ -1,12 +1,14 @@
 const { appTarget, publicPath } = require("../../../../helpers/paths");
 const {
   shouldAddContentHash,
+  getAppName,
 } = require("../../../../helpers/buildConfigHelpers");
 
 module.exports = {
   output: {
     path: appTarget,
     publicPath,
+    chunkLoadingGlobal: `${getAppName()}.globalLoadingChunk`,
     filename: shouldAddContentHash()
       ? "js/[name].[contenthash].legacy.js"
       : "js/[name].legacy.js",

--- a/packages/pv-scripts/webpack/base/settings/output/module.js
+++ b/packages/pv-scripts/webpack/base/settings/output/module.js
@@ -1,12 +1,14 @@
 const { appTarget, publicPath } = require("../../../../helpers/paths");
 const {
   shouldAddContentHash,
+  getAppName,
 } = require("../../../../helpers/buildConfigHelpers");
 
 module.exports = {
   output: {
     path: appTarget,
     publicPath,
+    chunkLoadingGlobal: `${getAppName()}.globalLoadingChunk`,
     filename: shouldAddContentHash()
       ? "js/[name].[contenthash].js"
       : "js/[name].js",


### PR DESCRIPTION


this will prevent any issues when loading third party plugins which are also bundled with webpack

== Description ==

It is on the edge case where we have multiple bundles which depend on each other and at the same time some third party js is loaded on the same page which also are webpack bundles.
The prefixing will prevent our chuncks for example call their bundle

The setting can also be done in the projeckts themselves. but i think having them in pv-scripts is better, will prevent future issues.

== Closes issue(s) ==


== Changes ==


== Affected Packages ==
pv-scripts