### PR TITLE
feat(pv-stylemark): add styling for table and blockquote from the markdown

### DIFF
--- a/packages/pv-stylemark/ui/components/dds-component/dds-component.scss
+++ b/packages/pv-stylemark/ui/components/dds-component/dds-component.scss
@@ -62,6 +62,38 @@
       }
     }
 
+    table {
+      display: block;
+      overflow: auto;
+      border-spacing: 0;
+      border-collapse: collapse;
+    }
+
+    th {
+      padding: 6px 12px;
+      border: 1px solid $dds-color__black-020;
+      font-weight: 600;
+    }
+
+    td {
+      padding: 6px 12px;
+      border: 1px solid $dds-color__black-020;
+    }
+
+    tr {
+      background-color: $dds-color__white;
+
+      &:nth-child(2n) {
+        background-color: $dds-color__black-000;
+      }
+    }
+
+    blockquote {
+      padding: 0 16px;
+      color: $dds-color__black-050;
+      border-left: 4px solid $dds-color__black-030;
+    }
+
     dds-example {
       margin: 24px 0 40px;
 


### PR DESCRIPTION


== Description ==
basic css for table and blcokquote. It will look similar to githubs tables etc, which is minimalistic but nice

== Closes issue(s) ==


== Changes ==


== Affected Packages ==
pv-stylemark