### PR TITLE
feat(pv-stylemark): add suport for js and html executable code blocks support the hidden attribute

### DIFF
--- a/packages/pv-stylemark/tasks/lsg/buildLsgExamples.js
+++ b/packages/pv-stylemark/tasks/lsg/buildLsgExamples.js
@@ -12,11 +12,22 @@ const loadTemplate = async hbsInst => {
   return hbsInst.compile(templateContent);
 };
 
+/**
+ * @param {Object} config
+ * @param {import("./getLsgData.js").StyleMarkLSGData} lsgData
+ * @param {import("./getLsgData.js").StyleMarkExampleData} exampleData
+ * @param {Function} template
+ */
 const buildComponentExample = async (config, lsgData, exampleData, template) => {
   const { destPath } = getAppConfig();
-  const componentPath = resolveApp(join(destPath, "components", lsgData.componentPath, exampleData.examplePath));
   try {
-    let componentMarkup = await readFile(componentPath, { encoding: "utf-8" });
+    let componentMarkup = "";
+    if (exampleData.exampleMarkup.examplePath) {
+      const componentPath = resolveApp(join(destPath, "components", lsgData.componentPath, exampleData.exampleMarkup.examplePath + ".html"));
+      componentMarkup = await readFile(componentPath, { encoding: "utf-8" });
+    } else {
+      componentMarkup = exampleData.exampleMarkup.content;
+    }
     const configBodyHtml = config.examples?.bodyHtml ?? "{html}";
     componentMarkup = configBodyHtml.replace(/{html}/g, componentMarkup);
     const markup = template({

--- a/packages/pv-stylemark/tasks/lsg/getLsgData.js
+++ b/packages/pv-stylemark/tasks/lsg/getLsgData.js
@@ -1,30 +1,58 @@
 const { readFile } = require("fs-extra");
-const { resolve, parse: pathParse, normalize, relative: relPath, dirname } = require("path");
+const { resolve, parse: pathParse, normalize, relative: relPath, join } = require("path");
 const { marked } = require("marked");
 const frontmatter = require("front-matter");
 const { glob } = require("glob");
 
 const { resolveApp, getAppConfig } = require("../../helper/paths");
 
-const getStylesData = stylesMatch => {
-  const exampleKeys = stylesMatch
-    .match(/^ *[\w\-]+\.css/)
-    .map(match => match.replace(/ /g, "").replace(/\.css$/g, ""));
-  if (exampleKeys.length === 0) return null;
+/**
+ * Information extracted from the executable code blocks according to the stylemark spec (@see https://github.com/mpetrovich/stylemark/blob/main/README-SPEC.md)
+ * @typedef {Object} StyleMarkCodeBlock
+ * @property {string} exampleName - will be used to identify the html page rendered as an iframe
+ * @property {string} [examplePath] - optional, will be a relative path to the html file (relative from target/components/path/to/markdown)
+ * @property {"html"|"css"|"js"} language - `html` will create a new html page, `js` and `css` will be added in the html file
+ * @property {"" | " hidden"} hidden - Indicates whether the code block should also be shown in the styleguide description of the component
+ * @property {string} content - the content of the code block
+ * @example
+ *    ```exampleName:examplePath.lang hidden
+ *      content
+ *    ```
+ */
 
-  const styleContent = stylesMatch.replace(/^ *[\w\-]+\.css( +hidden)?\s+/g, "").trim();
-  return {
-    exampleKey: exampleKeys[0],
-    styleContent,
-  };
-};
+/**
+ * @typedef {{
+ *  exampleName: string;
+ *  exampleMarkup: StyleMarkCodeBlock;
+ *  exampleStyles: StyleMarkCodeBlock[];
+ *  exampleScripts: StyleMarkCodeBlock[];
+ * }} StyleMarkExampleData
+ */
 
-const getExampleMarkup = (matchingString, name, componentPath) => {
-  matchingString = matchingString.replace(/```/g, "").replace(/\s/g, "");
-  const [exampleName, examplePath] = matchingString.split(":");
-  const markupUrl = `../components/${componentPath}/${examplePath}`;
-  return `<dds-example name="${exampleName}" path="${name}-${exampleName}.html" markup-url="${markupUrl}"></dds-example>`;
-};
+/**
+ * @typedef {{
+ *  componentName: string;
+ *  componentPath: string;
+ *  options: Object;
+ *  description: string;
+ *  examples: Array<StyleMarkExampleData>;
+ * }} StyleMarkLSGData
+ */
+
+// example code blocks
+// ```example:/path/to/page.html
+// ```
+//
+// ```example.js
+//   console.log('Example 1: ' + data);
+// ```
+//
+// ```example.css hidden
+//   button {
+//     display: none;
+//   }
+// ```
+const regexExecutableCodeBlocks = /``` *(?<exampleName>[\w\-]+)(:(?<examplePath>(\.?\.\/)*[\w\-/]+))?\.(?<language>html|css|js)(?<hidden>( hidden)?) *\n+(?<content>[^```]*)```/g;
 
 const exampleParser = {
   name: "exampleParser",
@@ -51,36 +79,36 @@ const exampleParser = {
   },
 };
 
-const getLsgDataForPath = async (path, componentsSrc) => {
-  const fileContent = await readFile(path, { encoding: "utf-8" });
+/**
+ * read markdown, extract code blocks for the individual examples
+ * @param {string} markdownPath
+ * @returns {StyleMarkLSGData}
+ */
+const getLsgDataForPath = async (markdownPath) => {
+  const fileContent = await readFile(markdownPath, { encoding: "utf-8" });
 
-  const { name } = pathParse(path);
-  const componentPath = dirname(relPath(resolveApp(componentsSrc), path));
+  const { name, dir } = pathParse(markdownPath);
+  const componentsSrc = resolveApp(getAppConfig().componentsSrc);
+  const componentPath = relPath(componentsSrc, dir);
 
   const { attributes: frontmatterData, body: fileContentBody } = frontmatter(fileContent);
 
-  const stylesRegex = new RegExp(/``` *[\w\-]+\.css( +hidden)? *\n+[^```]+```/g);
+  const codeBlocks = await getExecutableCodeBlocks(fileContentBody);
 
-  const stylesMatches = fileContentBody.match(stylesRegex) || [];
+  const exampleNames = codeBlocks.filter(({language}) => language === "html").map(({ exampleName }) => exampleName);
+  const exampleData = exampleNames.map(name => ({
+    exampleName: name,
+    // assuming only one html (external file or as the content of the fenced code block) is allowed per example
+    exampleMarkup: codeBlocks.find(({ exampleName, language }) => exampleName === name && language === "html"),
+    // multiple css/js code blocks are allowed per example
+    exampleStyles: codeBlocks.filter(({ exampleName, language }) => exampleName === name && language === "css"),
+    exampleScripts: codeBlocks.filter(({ exampleName, language }) => exampleName === name && language === "js"),
+  }));
 
-  const styles = stylesMatches.map(match => match.replace(/```/g, ""));
-  const stylesList = styles.map(getStylesData);
-
-  const exampleRegex = new RegExp(/``` *[\w\-]+:(\.?\.\/)*[\w\-/]+\.[a-z]+\s*\n```/g);
-
-  const exampleMatches = fileContentBody.match(exampleRegex) || [];
-  const examples = exampleMatches.map(match => match.replace(/```/g, "").replace(/\s/g, ""));
-  const exampleData = examples.map(match => {
-    const [exampleName, examplePath] = match.split(":");
-    const exampleStyles = stylesList.filter(style => style.exampleKey === exampleName);
-    return { exampleName, examplePath, exampleStyles };
-  });
-
-  const cleanContent = fileContentBody
-    .replace(exampleRegex, match => getExampleMarkup(match, name, componentPath))
-    .replace(stylesRegex, "");
+  const cleanContent = cleanMarkdownFromExecutableCodeBlocks(fileContentBody, name, componentPath);
   marked.use({ extensions: [exampleParser] });
   const description = marked.parse(cleanContent);
+
   return {
     componentName: name,
     componentPath,
@@ -120,15 +148,57 @@ const getDataSortedByCategory = (lsgData, config) => {
 };
 
 const getLsgData = async (curGlob, config) => {
-  const { componentsSrc } = getAppConfig();
   const paths = await glob(curGlob, {
     windowsPathsNoEscape: true,
   });
   const normalizedPaths = paths.map(filePath => normalize(resolve(process.cwd(), filePath)));
 
-  const data = await Promise.all(normalizedPaths.map(curPath => getLsgDataForPath(curPath, componentsSrc)));
+  const data = await Promise.all(normalizedPaths.map(curPath => getLsgDataForPath(curPath)));
   return getDataSortedByCategory(data, config);
 };
+
+/**
+ * extracts the fenced code blocks from the markdown that are meant to be used in the example pages according to the stylemark spec (@link https://github.com/mpetrovich/stylemark/blob/main/README-SPEC.md)
+ *
+ * @param {string} markdownContent
+ * @returns {Array<StyleMarkCodeBlock>}
+ */
+async function getExecutableCodeBlocks(markdownContent) {
+  return Array.from(markdownContent.matchAll(regexExecutableCodeBlocks))
+    .map(match => match.groups);
+}
+
+/**
+ * removes all the fenced code blocks that stylemark will use to render the examples,
+ * but only for the ones referencing an external file or having the `hidden` attribute in the info string
+ *
+ * @param {string} markdownContent
+ * @returns {string}
+ */
+function cleanMarkdownFromExecutableCodeBlocks(markdownContent, name, componentPath) {
+  return markdownContent.replace(regexExecutableCodeBlocks, (...args) => {
+    let replacement = "";
+    /** @type {StyleMarkCodeBlock} */
+    const groups = args.at(-1);
+
+    if (groups.language === "html") {
+      // html file will be generated for html code blocks without a referenced file
+      const examplePath = groups.examplePath ? `${groups.examplePath}.html` : `${groups.exampleName}.html`;
+      const markupUrl = join("../components", componentPath, examplePath);
+      replacement += `<dds-example name="${groups.exampleName}" path="${name}-${groups.exampleName}.html" ${groups.examplePath && !groups.hidden ? `markup-url="${markupUrl}"`: ""}></dds-example>`
+    }
+    if (groups.content && !groups.hidden) {
+      // add the css/js code blocks for the example. make sure it is indented the way `marked` can handle it
+      replacement += `
+<details>
+  <summary class="dds-example__code-box-toggle">${groups.language}</summary>
+  \n\`\`\`${groups.language}\n${groups.content}\n\`\`\`\n
+</details>`;
+    }
+
+    return replacement;
+  });
+}
 
 module.exports = {
   getLsgData,

--- a/packages/pv-stylemark/tasks/lsg/getLsgData.js
+++ b/packages/pv-stylemark/tasks/lsg/getLsgData.js
@@ -33,6 +33,7 @@ const { resolveApp, getAppConfig } = require("../../helper/paths");
  * @typedef {{
  *  componentName: string;
  *  componentPath: string;
+ *  srcPath: string;
  *  options: Object;
  *  description: string;
  *  examples: Array<StyleMarkExampleData>;
@@ -90,6 +91,7 @@ const getLsgDataForPath = async (markdownPath) => {
   const { name, dir } = pathParse(markdownPath);
   const componentsSrc = resolveApp(getAppConfig().componentsSrc);
   const componentPath = relPath(componentsSrc, dir);
+  const srcPath = relPath(componentsSrc, markdownPath);
 
   const { attributes: frontmatterData, body: fileContentBody } = frontmatter(fileContent);
 
@@ -112,6 +114,7 @@ const getLsgDataForPath = async (markdownPath) => {
   return {
     componentName: name,
     componentPath,
+    srcPath,
     options: frontmatterData,
     description,
     examples: exampleData,

--- a/packages/pv-stylemark/tasks/templates/lsg-component.hbs
+++ b/packages/pv-stylemark/tasks/templates/lsg-component.hbs
@@ -1,5 +1,9 @@
 <section class="dds-component" id="{{componentName}}">
   <h2 class="dds-component__name">{{options.name}}</h2>
+  <h2 class="dds-component__source theme-content-element-source">
+    <span class="dds-component__source-label theme-content-element-source-label">Source:</span>
+    <span class="dds-component__source-path theme-content-element-source-path">{{srcPath}}</span>
+  </h3>
   <div class="dds-component__description">
 {{{description}}}
   </div>

--- a/packages/pv-stylemark/tasks/templates/lsg-example.hbs
+++ b/packages/pv-stylemark/tasks/templates/lsg-example.hbs
@@ -5,11 +5,16 @@
     {{{lsgConfig.examples.headHtml}}}
     {{#each exampleStyles}}
       <style>
-        {{this.styleContent}}
+        {{content}}
       </style>
     {{/each}}
   </head>
   <body>
     {{{componentMarkup}}}
+    {{#each exampleScripts}}
+      <script>
+        {{content}}
+      </script>
+    {{/each}}
   </body>
 </html>

--- a/packages/pv-stylemark/ui/components/dds-component/dds-component.scss
+++ b/packages/pv-stylemark/ui/components/dds-component/dds-component.scss
@@ -11,6 +11,23 @@
     margin: 0 0 24px;
   }
 
+  &__source {
+    margin-bottom: 24px;
+    font-size: 14px;
+    font-weight: normal;
+    color: $dds-color__black-040;
+  }
+
+  &__source-label {
+    margin-right: 4px;
+    font-weight: 700;
+    text-transform: uppercase;
+  }
+
+  &__source-path {
+    font-family: Courier, monospace;
+  }
+
   &__description {
     h1 {
       @extend %dds-typo__headline-1;

--- a/packages/pv-stylemark/ui/components/dds-example/dds-example.scss
+++ b/packages/pv-stylemark/ui/components/dds-example/dds-example.scss
@@ -43,7 +43,8 @@ dds-example {
     }
   }
 
-  &__html-box-toggle {
+  &__html-box-toggle,
+  &__code-box-toggle {
     display: flex;
     gap: 8px;
     align-items: center;
@@ -76,9 +77,20 @@ dds-example {
       border-bottom: 5px solid transparent;
       border-left: 6px solid $dds-color__black-040;
 
-      .dds-state--open & {
+      .dds-state--open &,
+      [open] & {
         transform: rotate(90deg);
       }
+    }
+  }
+
+  &__code-box-toggle {
+    margin-top: 16px;
+
+    + pre {
+      margin: 0;
+      padding: 24px;
+      background: $dds-color__black-010;
     }
   }
 

--- a/packages/pv-stylemark/ui/components/dds-example/dds-example.ts
+++ b/packages/pv-stylemark/ui/components/dds-example/dds-example.ts
@@ -54,7 +54,7 @@ class DSExample extends HTMLElement {
     this.renderComponent();
     window.addEventListener('click', () => this.handleWindowClick());
     this.viewportObserver = new IntersectionObserver(
-      (entries) => this.handleViewportChange(entries), 
+      (entries) => this.handleViewportChange(entries),
       {
         threshold: 0
       }
@@ -65,7 +65,7 @@ class DSExample extends HTMLElement {
   private renderComponent() {
     this.renderExampleLink();
     this.renderExampleBox();
-    this.renderHtmlBox();
+    if (this.markupUrl) this.renderHtmlBox();
   }
 
   private renderExampleLink() {


### PR DESCRIPTION
== Description ==
The original stylemark allowed different types of fenced code blocks that contained the content for the examples: [Executable code blocks spec](https://github.com/mpetrovich/stylemark/blob/main/README-SPEC.md)

This PR will add support for these two variations:

~~~txt

```example.js
console.log();
```

```example.html
<button></button>
```

~~~

The embeded html code is handy if the components are mostly self rendering custom elements which don't need much html. This will allow to showcase them in different variations better integrated in the markdown (e.g. each option is described and an example added right after. without the need to create a hbs file for each example or put all examples in the same page)


Also added support for the `hidden` attribute (or rather the lack of). This is mainly to provide backwards compatibility and the use case is something like this where you want to execute some code and also show it in the readme at the same time.

~~~txt

Use the dialog as a modal:

```example.js
dialog.modal = true;
dialog.open();
```

```example:dialog.html
```

~~~

What is still missing is support for js and css files:

~~~txt
```example:path/to/script.js
```
~~~

But it is a little unclear e.g. the path is relative to where? the target folder as is for the html files or the markdown file in the src where the developer is writing the content and then do they expect stylemark to copy those files to target? does it need to maintain the same folder structure or can they be copied flat to `styleguide`? how they should be loaded, in head or in body? as sync script or async or type module etc? or make these all configurable?



---

Right now of course the new styleguide needs to be backwards compatible to make the transition easier, but i would argue for instead of the original stylemark pattern `example.html` change it to `html example`:

~~~css
```css example
foo {
  display: none;
}
```
~~~

This is more markdown spec comform and allows the IDE's to syntax highlight the content. similarly for referenced files i would also replace the `:` notation with using a space for more consistence, easier readability for the developer and easier parsing for us. (`key=value` pairs is also an option that [has precedence ](https://github.github.com/gfm/#example-113)) This would allow passing query params or even load the files with some other extension. Or even have additional options `hidden`, `collapsed`, `height` of iframe etc.

~~~

```html example demo/comp.html?foo=bar#anchor height=content collapsed=true
```

```js example http://cdn/lib.mjs type=module hidden
```
~~~



== Closes issue(s) ==


== Changes ==


== Affected Packages ==
pv-stylemark