### PR TITLE
feat(assemble-lite, pv-stylemark, vscode-pv-handlebars-language-server): data for templates from js

### DIFF
--- a/packages/assemble-lite/README.md
+++ b/packages/assemble-lite/README.md
@@ -42,3 +42,22 @@ assembleLite({
 | data      | glob \| glob[]  | where is the data                         |
 | helpers   | glob \| glob[]  | where are the custom handlebars-helpers (the collection from [handlebars-helpers](https://www.npmjs.com/package/handlebars-helpers) is already included - out of the box)                   |
 | target        | glob \| glob[]  | defines, where to put the rendered files  |
+
+## Data Files
+
+When generating html files, you can provide some data to be passed to the handlebars template and pages.
+
+These data can be local to the template and would only be applied to it, when set as yaml front-matter in the .hbs file.
+Or be global and accessible by all the templates via the handlebars `@root` object. Global data are all `.json`, `.yaml`, `.yml` and `*__data.js` files in the src and pages directory. The js file would need to have a default function that returns a json. This function can also return a promise, but keep in mind that this will slow down the build time and make build caching more difficult.
+
+```js
+// some-component__data.js
+
+module.exports = async function() {
+  await someFileSystemIO();
+
+  return {
+    // the actual data
+  };
+}
+```

--- a/packages/assemble-lite/helper/data-helper.js
+++ b/packages/assemble-lite/helper/data-helper.js
@@ -18,6 +18,10 @@ const loadData = async (data) => {
         dataPool[filename] = load(await readFile(path, "utf-8"), {
           filename,
         });
+      } else if (ext === ".js") {
+        const provider = require(path);
+        dataPool[filename] =
+          typeof provider === "function" ? await provider() : provider;
       }
     })
   );

--- a/packages/pv-stylemark/tasks/clickdummy/assembleClickdummyComponents.js
+++ b/packages/pv-stylemark/tasks/clickdummy/assembleClickdummyComponents.js
@@ -6,8 +6,8 @@ const { destPath, cdTemplatesSrc, componentsSrc, hbsHelperSrc } = getAppConfig()
 
 function* composeDataPaths(...fileExtensions) {
   for (const ext of fileExtensions) {
-    yield resolveApp(join(componentsSrc, `**/*.${ext}`));
-    yield resolveApp(join(cdTemplatesSrc, `*.${ext}`));
+    yield resolveApp(join(componentsSrc, `**/*${ext}`));
+    yield resolveApp(join(cdTemplatesSrc, `*${ext}`));
   }
 }
 
@@ -17,7 +17,7 @@ const assembleClickdummyComponents = () => {
     partials: resolveApp(join(componentsSrc, "**/*.hbs")),
     pages: resolveApp(join(componentsSrc, "**/*.hbs")),
     templates: resolveApp(join(cdTemplatesSrc, "**/*.hbs")),
-    data: [...composeDataPaths("json", "yaml", "yml")],
+    data: [...composeDataPaths(".json", ".yaml", ".yml", "__data.js"), ],
     helpers: resolveApp(join(hbsHelperSrc, "*.js")),
     target: resolveApp(join(destPath, "components")),
   });

--- a/packages/pv-stylemark/tasks/clickdummy/assembleClickdummyPages.js
+++ b/packages/pv-stylemark/tasks/clickdummy/assembleClickdummyPages.js
@@ -14,6 +14,7 @@ const assembleClickdummyPages = () => {
       resolveApp(join(componentsSrc, "**/*.json")),
       resolveApp(join(componentsSrc, "**/*.yaml")),
       resolveApp(join(componentsSrc, "**/*.yml")),
+      resolveApp(join(componentsSrc, "**/*__data.js")),
     ],
     helpers: resolveApp(join(hbsHelperSrc, "*.js")),
     target: resolveApp(join(destPath, "pages")),

--- a/packages/pv-stylemark/webpack-plugin/getFilesToWatch.js
+++ b/packages/pv-stylemark/webpack-plugin/getFilesToWatch.js
@@ -18,6 +18,7 @@ const getFilesToWatch = async () => {
       // add .yaml/.yml Component files
       ...(await asyncGlob(join(componentsSrc, "**/*.yaml"))),
       ...(await asyncGlob(join(componentsSrc, "**/*.yml"))),
+      ...(await asyncGlob(join(componentsSrc, "**/*__data.js"))),
       // handlebars helpers
       ...(await asyncGlob(join(hbsHelperSrc, "*.js"))),
       // add .hbs Components files

--- a/packages/vscode-pv-handlebars-language-server/server/src/helpers.ts
+++ b/packages/vscode-pv-handlebars-language-server/server/src/helpers.ts
@@ -131,7 +131,7 @@ export async function getPartials(componentsRootPath: string): Promise<Array<{ p
  * @returns {Promise<Array<{ path: string, name: string }>>}
  */
 export async function getDataFiles(componentsRootPath: string): Promise<Array<{ path: string; name: string }>> {
-  const partialPaths = await globby(`${componentsRootPath}/**/*.{json,yaml,yml}`);
+  const partialPaths = await globby(`${componentsRootPath}/**/*{.{json,yaml,yml},__data.js}`);
   return partialPaths.map(filePath => ({ path: filePath, name: basename(filePath) }));
 }
 


### PR DESCRIPTION
add support for js files providing the data used for generating the html files via assemble-lite

re #235

== Description ==


== Closes issue(s) ==


== Changes ==


== Affected Packages ==
assemble-lite
pv-stylemark
vscode-pv-handlebars-language-server