### PR TITLE
feat(pv-scripts): remove postCss's dir plugin setting

### DIFF
--- a/packages/pv-scripts/webpack/base/tasks/compileCSS.js
+++ b/packages/pv-scripts/webpack/base/tasks/compileCSS.js
@@ -30,9 +30,7 @@ module.exports = {
                   [
                     require.resolve("postcss-preset-env"),
                     {
-                      features: {
-                        "dir-pseudo-class": { dir: "ltr" },
-                      },
+                      features: {},
                     },
                   ],
                   [


### PR DESCRIPTION
== Description ==

all modern browsers (with regards to pv-scripts .browserslistrc) support the `:dir()` selector, having some setting in the post-css-env for the postcss-dir-pseudo-class plugin, will force converting this to `[dir=rtl]` which won't work with nested `dir`s or `dir=auto` or shadow dom.


== Affected Packages ==

pv-scripts