### PR TITLE
fix(pv-scripts): update sass-loader version

### DIFF
--- a/packages/pv-scripts/package-lock.json
+++ b/packages/pv-scripts/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@pro-vision/pv-scripts",
-			"version": "4.2.0",
+			"version": "5.0.1",
 			"license": "ISC",
 			"dependencies": {
 				"@babel/core": "7.24.4",
@@ -39,7 +39,7 @@
 				"react-dev-utils": "11.0.4",
 				"resolve": "1.22.2",
 				"sass": "1.75.0",
-				"sass-loader": "14.2.1",
+				"sass-loader": "16.0.2",
 				"slash": "3.0.0",
 				"source-map-explorer": "2.5.3",
 				"source-map-loader": "5.0.0",
@@ -53,6 +53,9 @@
 			},
 			"bin": {
 				"pv-scripts": "bin/pv-scripts.js"
+			},
+			"engines": {
+				"node": ">=18.12.0"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -11492,9 +11495,9 @@
 			}
 		},
 		"node_modules/sass-loader": {
-			"version": "14.2.1",
-			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-14.2.1.tgz",
-			"integrity": "sha512-G0VcnMYU18a4N7VoNDegg2OuMjYtxnqzQWARVWCIVSZwJeiL9kg8QMsuIZOplsJgTzZLF6jGxI3AClj8I9nRdQ==",
+			"version": "16.0.2",
+			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.2.tgz",
+			"integrity": "sha512-Ll6iXZ1EYwYT19SqW4mSBb76vSSi8JgzElmzIerhEGgzB5hRjDQIWsPmuk1UrAXkR16KJHqVY0eH+5/uw9Tmfw==",
 			"dependencies": {
 				"neo-async": "^2.6.2"
 			},
@@ -21596,9 +21599,9 @@
 			}
 		},
 		"sass-loader": {
-			"version": "14.2.1",
-			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-14.2.1.tgz",
-			"integrity": "sha512-G0VcnMYU18a4N7VoNDegg2OuMjYtxnqzQWARVWCIVSZwJeiL9kg8QMsuIZOplsJgTzZLF6jGxI3AClj8I9nRdQ==",
+			"version": "16.0.2",
+			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.2.tgz",
+			"integrity": "sha512-Ll6iXZ1EYwYT19SqW4mSBb76vSSi8JgzElmzIerhEGgzB5hRjDQIWsPmuk1UrAXkR16KJHqVY0eH+5/uw9Tmfw==",
 			"requires": {
 				"neo-async": "^2.6.2"
 			}

--- a/packages/pv-scripts/package.json
+++ b/packages/pv-scripts/package.json
@@ -58,7 +58,7 @@
 		"react-dev-utils": "11.0.4",
 		"resolve": "1.22.2",
 		"sass": "1.75.0",
-		"sass-loader": "14.2.1",
+		"sass-loader": "16.0.2",
 		"slash": "3.0.0",
 		"source-map-explorer": "2.5.3",
 		"source-map-loader": "5.0.0",


### PR DESCRIPTION
this fixes using newer sass(-embedded) where the legacy sass JS API is deprecated

== Description ==


== Closes issue(s) ==


== Changes ==


== Affected Packages ==
pv-scripts