### PR TITLE
feat(pv-scripts): resolve paths to assets, relative to the scss file with the reference itself

### DIFF
--- a/packages/pv-scripts/package-lock.json
+++ b/packages/pv-scripts/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@pro-vision/pv-scripts",
-			"version": "5.0.1",
+			"version": "5.1.0",
 			"license": "ISC",
 			"dependencies": {
 				"@babel/core": "7.26.0",
@@ -38,6 +38,7 @@
 				"postcss-preset-env": "10.1.1",
 				"react-dev-utils": "11.0.4",
 				"resolve": "1.22.8",
+				"resolve-url-loader": "5.0.0",
 				"sass": "1.75.0",
 				"sass-loader": "16.0.3",
 				"slash": "3.0.0",
@@ -3455,6 +3456,33 @@
 			"integrity": "sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA==",
 			"engines": {
 				"node": ">= 0.12.0"
+			}
+		},
+		"node_modules/adjust-sourcemap-loader": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-4.0.0.tgz",
+			"integrity": "sha512-OXwN5b9pCUXNQHJpwwD2qP40byEmSgzj8B4ydSN0uMNYWiFmJ6x6KwUllMmfk8Rwu/HJDFR7U8ubsWBoN0Xp0A==",
+			"license": "MIT",
+			"dependencies": {
+				"loader-utils": "^2.0.0",
+				"regex-parser": "^2.2.11"
+			},
+			"engines": {
+				"node": ">=8.9"
+			}
+		},
+		"node_modules/adjust-sourcemap-loader/node_modules/loader-utils": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+			"integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+			"license": "MIT",
+			"dependencies": {
+				"big.js": "^5.2.2",
+				"emojis-list": "^3.0.0",
+				"json5": "^2.1.2"
+			},
+			"engines": {
+				"node": ">=8.9.0"
 			}
 		},
 		"node_modules/agent-base": {
@@ -11197,6 +11225,12 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/regex-parser": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.3.1.tgz",
+			"integrity": "sha512-yXLRqatcCuKtVHsWrNg0JL3l1zGfdXeEvDa0bdu4tCDQw0RpMDZsqbkyRTUnKMR0tXF627V2oEWjBEaEdqTwtQ==",
+			"license": "MIT"
+		},
 		"node_modules/regexpu-core": {
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.2.0.tgz",
@@ -11315,6 +11349,36 @@
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
 			"integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
 			"deprecated": "https://github.com/lydell/resolve-url#deprecated"
+		},
+		"node_modules/resolve-url-loader": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-5.0.0.tgz",
+			"integrity": "sha512-uZtduh8/8srhBoMx//5bwqjQ+rfYOUq8zC9NrMUGtjBiGTtFJM42s58/36+hTqeqINcnYe08Nj3LkK9lW4N8Xg==",
+			"license": "MIT",
+			"dependencies": {
+				"adjust-sourcemap-loader": "^4.0.0",
+				"convert-source-map": "^1.7.0",
+				"loader-utils": "^2.0.0",
+				"postcss": "^8.2.14",
+				"source-map": "0.6.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/resolve-url-loader/node_modules/loader-utils": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+			"integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+			"license": "MIT",
+			"dependencies": {
+				"big.js": "^5.2.2",
+				"emojis-list": "^3.0.0",
+				"json5": "^2.1.2"
+			},
+			"engines": {
+				"node": ">=8.9.0"
+			}
 		},
 		"node_modules/ret": {
 			"version": "0.1.15",
@@ -15818,6 +15882,27 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/address/-/address-1.1.2.tgz",
 			"integrity": "sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA=="
+		},
+		"adjust-sourcemap-loader": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-4.0.0.tgz",
+			"integrity": "sha512-OXwN5b9pCUXNQHJpwwD2qP40byEmSgzj8B4ydSN0uMNYWiFmJ6x6KwUllMmfk8Rwu/HJDFR7U8ubsWBoN0Xp0A==",
+			"requires": {
+				"loader-utils": "^2.0.0",
+				"regex-parser": "^2.2.11"
+			},
+			"dependencies": {
+				"loader-utils": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+					"integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+					"requires": {
+						"big.js": "^5.2.2",
+						"emojis-list": "^3.0.0",
+						"json5": "^2.1.2"
+					}
+				}
+			}
 		},
 		"agent-base": {
 			"version": "6.0.2",
@@ -21213,6 +21298,11 @@
 				"safe-regex": "^1.1.0"
 			}
 		},
+		"regex-parser": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.3.1.tgz",
+			"integrity": "sha512-yXLRqatcCuKtVHsWrNg0JL3l1zGfdXeEvDa0bdu4tCDQw0RpMDZsqbkyRTUnKMR0tXF627V2oEWjBEaEdqTwtQ=="
+		},
 		"regexpu-core": {
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.2.0.tgz",
@@ -21300,6 +21390,30 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
 			"integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg=="
+		},
+		"resolve-url-loader": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-5.0.0.tgz",
+			"integrity": "sha512-uZtduh8/8srhBoMx//5bwqjQ+rfYOUq8zC9NrMUGtjBiGTtFJM42s58/36+hTqeqINcnYe08Nj3LkK9lW4N8Xg==",
+			"requires": {
+				"adjust-sourcemap-loader": "^4.0.0",
+				"convert-source-map": "^1.7.0",
+				"loader-utils": "^2.0.0",
+				"postcss": "^8.2.14",
+				"source-map": "0.6.1"
+			},
+			"dependencies": {
+				"loader-utils": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+					"integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+					"requires": {
+						"big.js": "^5.2.2",
+						"emojis-list": "^3.0.0",
+						"json5": "^2.1.2"
+					}
+				}
+			}
 		},
 		"ret": {
 			"version": "0.1.15",

--- a/packages/pv-scripts/package.json
+++ b/packages/pv-scripts/package.json
@@ -57,6 +57,7 @@
 		"postcss-preset-env": "10.1.1",
 		"react-dev-utils": "11.0.4",
 		"resolve": "1.22.8",
+		"resolve-url-loader": "5.0.0",
 		"sass": "1.75.0",
 		"sass-loader": "16.0.3",
 		"slash": "3.0.0",

--- a/packages/pv-scripts/webpack/base/tasks/compileCSS.js
+++ b/packages/pv-scripts/webpack/base/tasks/compileCSS.js
@@ -21,6 +21,12 @@ module.exports = {
             },
           },
           {
+            loader: require.resolve("resolve-url-loader"),
+            options: {
+              sourceMap: true,
+            },
+          },
+          {
             loader: require.resolve("postcss-loader"),
             options: {
               implementation: require("postcss"),


### PR DESCRIPTION



== Description ==
Instead of any asset reference in scss (url() for images, fonts etc) being resolved relative to the entry file. It will be resolved relative to the file itself. This allows sharing the same scss file between different entries / bundles. and improves IDE support (e.g. autocompletation, goto definition). (See https://www.npmjs.com/package/resolve-url-loader )

BREAKING CHANGE: Any relative paths being used in the scss file (e.g. `background-image: url(./path/to/sceleton.svg)`) which was previously relative to the entry file (e.g. index.scss) needs to be replaced with the relative path from the scss with the rule referencing the asset.

== Closes issue(s) ==


== Changes ==


== Affected Packages ==
pv-scripts