### PR TITLE
(pv-create-component) Create Component script updates

### DIFF
--- a/packages/pv-create-component/config.js
+++ b/packages/pv-create-component/config.js
@@ -135,7 +135,7 @@ module.exports = [
         when: (options) => options.hasScss,
         path: SCSS_MAIN,
         template: (options) =>
-          `@import "../components/${options.componentName}/${options.componentName}";`,
+          `@use "../components/${options.componentName}/${options.componentName}";`,
       },
     ],
   },

--- a/packages/pv-create-component/config.js
+++ b/packages/pv-create-component/config.js
@@ -3,6 +3,7 @@
 const { resolve: pathResolve } = require("path");
 
 const COMPONENTS_DIR = "src/components";
+const PAGES_DIR = "src/pages";
 const TEMPLATES_DIR = "scripts/create-component/templates";
 const SCSS_MAIN = "src/styles/index.scss";
 const PAGES_MAIN = "src/styleguide/index.html";
@@ -95,7 +96,7 @@ module.exports = [
         id: "PAGE-FILE",
         when: (options) => options.type === COMPONENT_TYPES.PAGE,
         template: (options) => getTemplate("hbsPageTemplate", options)(options),
-        path: (options) => `${options.kebabCase}.hbs`,
+        path: (options) => `${PAGES_DIR}/${options.kebabCase}.hbs`,
       },
     ],
     imports: [


### PR DESCRIPTION
== Description ==
- Fix default config creating hbs page in the root directory instead of "src/pages".
- use `@use` instead of `@import` for component stylesheet imports. This aligns with the new sass syntax and prepares for `@import` being removed in dart-sass v3.0.0

== Closes issue(s) ==


== Changes ==


== Affected Packages ==
pv-create-component